### PR TITLE
feat: support i18next Selector API (`t($ => $.key)`)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,6 +34,11 @@ Configuration can be provided via:
   },
   "indexing": {
     "numThreads": null
+  },
+  "frameworks": {
+    "i18next": {
+      "preferSelector": false
+    }
   }
 }
 ```
@@ -188,6 +193,34 @@ Example:
 `number?` (default: 40% of CPU cores)
 
 Number of parallel threads for workspace indexing.
+
+---
+
+## frameworks
+
+Per-framework configuration.
+
+### frameworks.i18next.preferSelector
+
+`boolean` (default: `false`)
+
+When `true`, completions at empty arguments (`t(|)`) insert i18next [Selector API](https://www.locize.com/blog/i18next-typescript-selector-api/) format instead of string format.
+
+| Value | Completion result |
+|-------|-------------------|
+| `false` | `t("common.hello")` |
+| `true` | `t(($) => $.common.hello)` |
+
+Example:
+```json
+{
+  "frameworks": {
+    "i18next": {
+      "preferSelector": true
+    }
+  }
+}
+```
 
 ---
 

--- a/docs/supported-syntax.md
+++ b/docs/supported-syntax.md
@@ -25,6 +25,12 @@ t("key", { interpolation: { escapeValue: false }, value: getData() })
 // Global calls
 i18n.t("key")
 i18next.t("key")
+
+// Selector API (i18next v25.4.0+)
+t(($) => $.key)
+t(($) => $.nested.key.path)
+t(($) => $.key, { count: 1 })
+t($ => $.key)  // Without parens
 ```
 
 ## Translation Function Acquisition
@@ -58,6 +64,7 @@ react-i18next JSX component patterns.
 <Trans i18nKey="key">Fallback content</Trans>
 <Trans i18nKey={"key"} />  // JSX expression supported
 <Trans i18nKey="key" t={customT} />  // Custom t function
+<Trans i18nKey={($) => $.key} />  // Selector API
 
 // Translation component (render props)
 <Translation>
@@ -97,6 +104,10 @@ t("name")  // → "form.fields.name"
 <Translation keyPrefix="form.fields">
   {(t) => t("name")}  {/* → "form.fields.name" */}
 </Translation>
+
+// Selector API with keyPrefix
+const { t } = useTranslation("ns", { keyPrefix: "form.fields" })
+t(($) => $.name)  // → "form.fields.name"
 ```
 
 ## svelte-i18n

--- a/playground/i18next/selectorApi.ts
+++ b/playground/i18next/selectorApi.ts
@@ -1,0 +1,90 @@
+/**
+ * Selector API の様々なパターン (i18next v25.4.0+)
+ *
+ * t($ => $.key) — アロー関数でキーを指定する型安全な API
+ */
+import i18n from "i18next";
+
+// 基本的な使い方
+function basicSelector() {
+  const t = i18n.t;
+
+  console.log(t(($) => $.common.hello));
+  console.log(t(($) => $.common.goodbye));
+}
+
+// 括弧なしのパラメータ
+function withoutParens() {
+  const t = i18n.t;
+
+  console.log(t($ => $.common.hello));
+  console.log(t($ => $.buttons.save));
+}
+
+// ネストしたキー
+function nestedKeys() {
+  const t = i18n.t;
+
+  console.log(t(($) => $.user.profile.name));
+  console.log(t(($) => $.user.profile.email));
+  console.log(t(($) => $.user.settings.language));
+  console.log(t(($) => $.user.settings.theme));
+}
+
+// 補間パラメータとの併用
+function withInterpolation() {
+  const t = i18n.t;
+
+  console.log(t(($) => $.common.welcome, { name: "World" }));
+}
+
+// getFixedT + Selector API
+function withGetFixedT() {
+  const t = i18n.getFixedT(null, "translation");
+
+  console.log(t(($) => $.common.hello));
+  console.log(t(($) => $.buttons.save));
+}
+
+// getFixedT + keyPrefix + Selector API
+function withGetFixedTAndKeyPrefix() {
+  const t = i18n.getFixedT(null, "translation", "common");
+
+  // 実際のキー: common.hello, common.goodbye
+  console.log(t(($) => $.hello));
+  console.log(t(($) => $.goodbye));
+}
+
+// getFixedT + keyPrefix (ネストしたキー)
+function withNestedKeyPrefix() {
+  const t = i18n.getFixedT(null, "translation", "user.profile");
+
+  // 実際のキー: user.profile.name, user.profile.email
+  console.log(t(($) => $.name));
+  console.log(t(($) => $.email));
+}
+
+// 文字列キーとの混在
+function mixedWithStringKeys() {
+  const t = i18n.t;
+
+  // 文字列キー
+  console.log(t("common.hello"));
+  // Selector API
+  console.log(t(($) => $.common.goodbye));
+  // 文字列キー
+  console.log(t("buttons.save"));
+  // Selector API
+  console.log(t(($) => $.buttons.cancel));
+}
+
+export {
+  basicSelector,
+  withoutParens,
+  nestedKeys,
+  withInterpolation,
+  withGetFixedT,
+  withGetFixedTAndKeyPrefix,
+  withNestedKeyPrefix,
+  mixedWithStringKeys,
+};

--- a/playground/namespace-demo/.js-i18n.json
+++ b/playground/namespace-demo/.js-i18n.json
@@ -6,5 +6,10 @@
   "keySeparator": ".",
   "namespaceSeparator": ":",
   "defaultNamespace": "translation",
-  "primaryLanguages": ["en", "ja"]
+  "primaryLanguages": ["en", "ja"],
+  "frameworks": {
+    "i18next": {
+      "preferSelector": true
+    }
+  }
 }

--- a/playground/namespace-demo/selector-api.tsx
+++ b/playground/namespace-demo/selector-api.tsx
@@ -1,0 +1,68 @@
+import { Trans, useTranslation } from "react-i18next";
+
+/**
+ * Selector API + Namespace パターン
+ *
+ * useTranslation に namespace を指定した上で Selector API を使用
+ */
+export function SelectorWithNamespace() {
+  const { t } = useTranslation("common");
+
+  return (
+    <div>
+      <h1>{t(($) => $.greeting.hello)}</h1>
+      <p>{t(($) => $.greeting.goodbye)}</p>
+
+      <button>{t(($) => $.button.save)}</button>
+      <button>{t(($) => $.button.cancel)}</button>
+    </div>
+  );
+}
+
+/**
+ * Selector API + 複数 Namespace
+ */
+export function SelectorMultipleNamespaces() {
+  const { t: tCommon } = useTranslation("common");
+  const { t: tErrors } = useTranslation("errors");
+
+  return (
+    <div>
+      <button>{tCommon(($) => $.button.delete)}</button>
+
+      <p>{tErrors(($) => $.notFound)}</p>
+      <p>{tErrors(($) => $.validation.required)}</p>
+    </div>
+  );
+}
+
+/**
+ * Selector API + 明示的な namespace オーバーライド
+ */
+export function SelectorExplicitNamespace() {
+  const { t } = useTranslation("common");
+
+  return (
+    <div>
+      {/* common namespace のキー */}
+      <h1>{t(($) => $.greeting.hello)}</h1>
+
+      {/* ns オプションで errors namespace に切り替え */}
+      <p>{t(($) => $.notFound, { ns: "errors" })}</p>
+      <p>{t(($) => $.validation.email, { ns: "errors" })}</p>
+    </div>
+  );
+}
+
+/**
+ * Selector API + Trans コンポーネント
+ */
+export function SelectorTrans() {
+  const { t } = useTranslation("common");
+
+  return (
+    <div>
+      <Trans i18nKey={($) => $.greeting.hello} t={t} />
+    </div>
+  );
+}

--- a/playground/react-i18next/selectorApi.tsx
+++ b/playground/react-i18next/selectorApi.tsx
@@ -1,0 +1,133 @@
+/**
+ * Selector API の様々なパターン (react-i18next + i18next v25.4.0+)
+ *
+ * t($ => $.key) — アロー関数でキーを指定する型安全な API
+ */
+import { Trans, useTranslation } from "react-i18next";
+
+// 基本的な使い方
+function BasicSelector() {
+  const { t } = useTranslation();
+
+  return (
+    <div>
+      <h1>{t(($) => $.common.hello)}</h1>
+      <p>{t(($) => $.common.goodbye)}</p>
+    </div>
+  );
+}
+
+// namespace を指定
+function WithNamespace() {
+  const { t } = useTranslation("translation");
+
+  return <h1>{t(($) => $.common.hello)}</h1>;
+}
+
+// keyPrefix との組み合わせ
+function WithKeyPrefix() {
+  const { t } = useTranslation("translation", { keyPrefix: "common" });
+
+  // 実際のキー: common.hello, common.goodbye
+  return (
+    <div>
+      <h1>{t(($) => $.hello)}</h1>
+      <p>{t(($) => $.goodbye)}</p>
+    </div>
+  );
+}
+
+// ネストしたキー
+function NestedKeys() {
+  const { t } = useTranslation();
+
+  return (
+    <div>
+      <p>{t(($) => $.user.profile.name)}</p>
+      <p>{t(($) => $.user.profile.email)}</p>
+      <p>{t(($) => $.user.settings.language)}</p>
+    </div>
+  );
+}
+
+// 補間パラメータとの併用
+function WithInterpolation() {
+  const { t } = useTranslation();
+
+  return <h1>{t(($) => $.common.welcome, { name: "World" })}</h1>;
+}
+
+// 文字列キーとの混在
+function MixedWithStringKeys() {
+  const { t } = useTranslation();
+
+  return (
+    <div>
+      {/* 文字列キー */}
+      <h1>{t("common.hello")}</h1>
+      {/* Selector API */}
+      <p>{t(($) => $.common.goodbye)}</p>
+      {/* 文字列キー */}
+      <button>{t("buttons.save")}</button>
+      {/* Selector API */}
+      <button>{t(($) => $.buttons.cancel)}</button>
+    </div>
+  );
+}
+
+// Trans コンポーネント + Selector API
+function TransWithSelector() {
+  const { t } = useTranslation();
+
+  return <Trans i18nKey={($) => $.trans.simple} t={t} />;
+}
+
+// Trans コンポーネント (self-closing) + Selector API
+function TransSelfClosingWithSelector() {
+  const { t } = useTranslation();
+
+  return <Trans i18nKey={($) => $.trans.with_component} t={t} components={{ link: <a href="/more" /> }} />;
+}
+
+// Trans コンポーネント (子要素あり) + Selector API
+function TransWithChildrenAndSelector() {
+  const { t } = useTranslation();
+
+  return (
+    <Trans i18nKey={($) => $.trans.with_component} t={t}>
+      Click <a href="/more">here</a> for more
+    </Trans>
+  );
+}
+
+// カスタム変数名
+function CustomVariableName() {
+  const { t: translate } = useTranslation();
+
+  return <h1>{translate(($) => $.common.hello)}</h1>;
+}
+
+// 関数スコープ内での使用
+function FunctionScope() {
+  const { t } = useTranslation();
+
+  const handleClick = () => {
+    alert(t(($) => $.common.hello));
+  };
+
+  return <button onClick={handleClick}>{t(($) => $.buttons.submit)}</button>;
+}
+
+export {
+  BasicSelector,
+  WithNamespace,
+  WithKeyPrefix,
+  NestedKeys,
+  WithInterpolation,
+  MixedWithStringKeys,
+  TransWithSelector,
+  TransSelfClosingWithSelector,
+  TransWithChildrenAndSelector,
+  CustomVariableName,
+  FunctionScope,
+};

--- a/queries/javascript/react-i18next.scm
+++ b/queries/javascript/react-i18next.scm
@@ -42,10 +42,35 @@
     ) @i18n.trans_args
 ) @i18n.call_trans_fn
 
+;; Selector API: t($ => $.a.b.c)
+(call_expression
+  function: [
+    (identifier) @i18n.call_trans_fn_name
+    (member_expression) @i18n.call_trans_fn_name
+  ]
+  arguments: (arguments
+    (arrow_function) @i18n.selector_fn
+    (_)*
+  ) @i18n.trans_args
+) @i18n.call_trans_fn
+
 ;; Capture explicit namespace: t("key", { ns: "namespace" })
 (call_expression
   arguments: (arguments
     (string)
+    (object
+      (pair
+        key: (property_identifier) @_ns_key (#eq? @_ns_key "ns")
+        value: (string (string_fragment) @i18n.explicit_namespace)
+      )
+    )
+  )
+)
+
+;; Capture explicit namespace (Selector API): t($ => $.key, { ns: "namespace" })
+(call_expression
+  arguments: (arguments
+    (arrow_function)
     (object
       (pair
         key: (property_identifier) @_ns_key (#eq? @_ns_key "ns")
@@ -91,6 +116,21 @@
   )?
 ) @i18n.call_trans_fn
 
+;; Trans コンポーネント (self-closing, Selector API)
+(jsx_self_closing_element
+  name: (identifier) @trans (#eq? @trans "Trans")
+  attribute: (jsx_attribute
+    (property_identifier) @i18n_key (#eq? @i18n_key "i18nKey")
+    (jsx_expression
+      (arrow_function) @i18n.selector_fn
+    )
+  )
+  attribute: (jsx_attribute
+    (property_identifier) @attr_t (#eq? @attr_t "t")
+    (jsx_expression (identifier) @i18n.call_trans_fn_name)
+  )?
+) @i18n.call_trans_fn
+
 ;; Trans コンポーネント (opening element)
 (jsx_opening_element
   name: (identifier) @trans (#eq? @trans "Trans")
@@ -100,6 +140,21 @@
       (string (string_fragment) @i18n.trans_key) @i18n.trans_key_arg
       (jsx_expression (string (string_fragment) @i18n.trans_key) @i18n.trans_key_arg)
     ]
+  )
+  attribute: (jsx_attribute
+    (property_identifier) @attr_t (#eq? @attr_t "t")
+    (jsx_expression (identifier) @i18n.call_trans_fn_name)
+  )?
+) @i18n.call_trans_fn
+
+;; Trans コンポーネント (opening element, Selector API)
+(jsx_opening_element
+  name: (identifier) @trans (#eq? @trans "Trans")
+  attribute: (jsx_attribute
+    (property_identifier) @i18n_key (#eq? @i18n_key "i18nKey")
+    (jsx_expression
+      (arrow_function) @i18n.selector_fn
+    )
   )
   attribute: (jsx_attribute
     (property_identifier) @attr_t (#eq? @attr_t "t")

--- a/queries/tsx/react-i18next.scm
+++ b/queries/tsx/react-i18next.scm
@@ -42,10 +42,35 @@
     ) @i18n.trans_args
 ) @i18n.call_trans_fn
 
+;; Selector API: t($ => $.a.b.c)
+(call_expression
+  function: [
+    (identifier) @i18n.call_trans_fn_name
+    (member_expression) @i18n.call_trans_fn_name
+  ]
+  arguments: (arguments
+    (arrow_function) @i18n.selector_fn
+    (_)*
+  ) @i18n.trans_args
+) @i18n.call_trans_fn
+
 ;; Capture explicit namespace: t("key", { ns: "namespace" })
 (call_expression
   arguments: (arguments
     (string)
+    (object
+      (pair
+        key: (property_identifier) @_ns_key (#eq? @_ns_key "ns")
+        value: (string (string_fragment) @i18n.explicit_namespace)
+      )
+    )
+  )
+)
+
+;; Capture explicit namespace (Selector API): t($ => $.key, { ns: "namespace" })
+(call_expression
+  arguments: (arguments
+    (arrow_function)
     (object
       (pair
         key: (property_identifier) @_ns_key (#eq? @_ns_key "ns")
@@ -91,6 +116,21 @@
   )?
 ) @i18n.call_trans_fn
 
+;; Trans コンポーネント (self-closing, Selector API)
+(jsx_self_closing_element
+  name: (identifier) @trans (#eq? @trans "Trans")
+  attribute: (jsx_attribute
+    (property_identifier) @i18n_key (#eq? @i18n_key "i18nKey")
+    (jsx_expression
+      (arrow_function) @i18n.selector_fn
+    )
+  )
+  attribute: (jsx_attribute
+    (property_identifier) @attr_t (#eq? @attr_t "t")
+    (jsx_expression (identifier) @i18n.call_trans_fn_name)
+  )?
+) @i18n.call_trans_fn
+
 ;; Trans コンポーネント (opening element)
 (jsx_opening_element
   name: (identifier) @trans (#eq? @trans "Trans")
@@ -100,6 +140,21 @@
       (string (string_fragment) @i18n.trans_key) @i18n.trans_key_arg
       (jsx_expression (string (string_fragment) @i18n.trans_key) @i18n.trans_key_arg)
     ]
+  )
+  attribute: (jsx_attribute
+    (property_identifier) @attr_t (#eq? @attr_t "t")
+    (jsx_expression (identifier) @i18n.call_trans_fn_name)
+  )?
+) @i18n.call_trans_fn
+
+;; Trans コンポーネント (opening element, Selector API)
+(jsx_opening_element
+  name: (identifier) @trans (#eq? @trans "Trans")
+  attribute: (jsx_attribute
+    (property_identifier) @i18n_key (#eq? @i18n_key "i18nKey")
+    (jsx_expression
+      (arrow_function) @i18n.selector_fn
+    )
   )
   attribute: (jsx_attribute
     (property_identifier) @attr_t (#eq? @attr_t "t")

--- a/queries/typescript/react-i18next.scm
+++ b/queries/typescript/react-i18next.scm
@@ -42,10 +42,35 @@
     ) @i18n.trans_args
 ) @i18n.call_trans_fn
 
+;; Selector API: t($ => $.a.b.c)
+(call_expression
+  function: [
+    (identifier) @i18n.call_trans_fn_name
+    (member_expression) @i18n.call_trans_fn_name
+  ]
+  arguments: (arguments
+    (arrow_function) @i18n.selector_fn
+    (_)*
+  ) @i18n.trans_args
+) @i18n.call_trans_fn
+
 ;; Capture explicit namespace: t("key", { ns: "namespace" })
 (call_expression
   arguments: (arguments
     (string)
+    (object
+      (pair
+        key: (property_identifier) @_ns_key (#eq? @_ns_key "ns")
+        value: (string (string_fragment) @i18n.explicit_namespace)
+      )
+    )
+  )
+)
+
+;; Capture explicit namespace (Selector API): t($ => $.key, { ns: "namespace" })
+(call_expression
+  arguments: (arguments
+    (arrow_function)
     (object
       (pair
         key: (property_identifier) @_ns_key (#eq? @_ns_key "ns")

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -66,6 +66,8 @@ pub struct I18nSettings {
 
     /// Fallback language priority when `currentLanguage` is unset.
     pub primary_languages: Option<Vec<String>>,
+
+    pub frameworks: FrameworksConfig,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, Default)]
@@ -239,6 +241,22 @@ impl Default for TranslationFilesConfig {
     }
 }
 
+/// Per-framework configuration.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct FrameworksConfig {
+    pub i18next: Option<I18nextConfig>,
+}
+
+/// i18next-specific settings.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct I18nextConfig {
+    /// When `true`, completions at `t(|)` insert selector format `($) => $.key`
+    /// instead of string format `"key"`.
+    pub prefer_selector: bool,
+}
+
 impl Default for I18nSettings {
     fn default() -> Self {
         Self {
@@ -251,6 +269,7 @@ impl Default for I18nSettings {
             indexing: IndexingConfig::default(),
             diagnostics: DiagnosticsConfig::default(),
             primary_languages: None,
+            frameworks: FrameworksConfig::default(),
         }
     }
 }
@@ -584,5 +603,22 @@ mod tests {
         assert_that!(error_message, contains_substring("cannot be empty"));
         assert_that!(error_message, contains_substring("2. includePatterns"));
         assert_that!(error_message, contains_substring("At least one pattern"));
+    }
+
+    #[rstest]
+    fn deserialize_frameworks_config() {
+        let json = r#"{"frameworks": {"i18next": {"preferSelector": true}}}"#;
+        let settings: I18nSettings = serde_json::from_str(json).unwrap();
+
+        assert_that!(settings.frameworks.i18next.is_some(), eq(true));
+        assert_that!(settings.frameworks.i18next.unwrap().prefer_selector, eq(true));
+    }
+
+    #[rstest]
+    fn deserialize_frameworks_config_defaults() {
+        let json = "{}";
+        let settings: I18nSettings = serde_json::from_str(json).unwrap();
+
+        assert_that!(settings.frameworks.i18next, none());
     }
 }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -242,14 +242,14 @@ impl Default for TranslationFilesConfig {
 }
 
 /// Per-framework configuration.
-#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct FrameworksConfig {
     pub i18next: Option<I18nextConfig>,
 }
 
 /// i18next-specific settings.
-#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct I18nextConfig {
     /// When `true`, completions at `t(|)` insert selector format `($) => $.key`

--- a/src/ide/completion.rs
+++ b/src/ide/completion.rs
@@ -47,6 +47,7 @@ pub struct CompletionContext {
 }
 
 /// Options for `generate_completions`.
+#[derive(Debug)]
 pub struct CompletionOptions<'a> {
     pub partial_key: Option<&'a str>,
     pub quote_context: &'a QuoteContext,

--- a/src/ide/completion.rs
+++ b/src/ide/completion.rs
@@ -203,30 +203,26 @@ pub fn generate_completions(
     completion_items
 }
 
-/// Extracts selector completion context from arrow function argument text.
+/// Extracts selector completion context from selector argument text.
 ///
-/// Parses text like `$ => $.common.hello` and returns body positions, param name, and partial key.
+/// Handles both full arrow function (`$ => $.common.hello`) and body-only (`$.common.hello`).
 #[allow(clippy::cast_possible_truncation)]
 fn extract_selector_context(
     arg_text: &str,
-    _arg_start_char: usize,
     arg_end_char: usize,
     arg_line: u32,
     cursor_char: usize,
     key_separator: &str,
-) -> Option<(Position, Position, String, String)> {
-    let arrow_pos = arg_text.find("=>")?;
-    let after_arrow = arg_text[arrow_pos + 2..].trim_start();
-    let body_start_char = arg_end_char - after_arrow.len();
+) -> (Position, Position, String, String) {
+    // Handle both `$ => $.key` (full arrow) and `$.key` (body only)
+    let body_text = arg_text.find("=>").map_or(arg_text, |pos| arg_text[pos + 2..].trim_start());
+    let body_start_char = arg_end_char - body_text.len();
 
-    let param_end = after_arrow.find(['.', '[']).unwrap_or(after_arrow.len());
-    let param_name = &after_arrow[..param_end];
+    let param_end = body_text.find(['.', '[']).unwrap_or(body_text.len());
+    let param_name = &body_text[..param_end];
 
-    let key_text_offset = if after_arrow.as_bytes().get(param_end) == Some(&b'.') {
-        param_end + 1
-    } else {
-        param_end
-    };
+    let key_text_offset =
+        if body_text.as_bytes().get(param_end) == Some(&b'.') { param_end + 1 } else { param_end };
 
     let key_start_char = body_start_char + key_text_offset;
 
@@ -245,7 +241,7 @@ fn extract_selector_context(
     let body_start = Position::new(arg_line, body_start_char as u32);
     let body_end = Position::new(arg_line, arg_end_char as u32);
 
-    Some((body_start, body_end, param_name.to_string(), partial_key))
+    (body_start, body_end, param_name.to_string(), partial_key)
 }
 
 /// Extracts completion context using tree-sitter.
@@ -304,17 +300,20 @@ pub fn extract_completion_context_tree_sitter(
 
         let arg_text = &arg_start_line[arg_start_char..arg_end_char];
 
-        // Selector API: t($ => $.common.hello) or t(($) => $.common.hello)
-        if arg_text.contains("=>")
-            && let Some((body_start, body_end, param_name, partial_key)) = extract_selector_context(
+        // Selector API: arrow function body like `$.common.hello` or full `$ => $.common.hello`
+        let is_selector_text = arg_text.contains("=>")
+            || (!arg_text.starts_with('"')
+                && !arg_text.starts_with('\'')
+                && !arg_text.starts_with('(')
+                && arg_text.find(['.', '[']).is_some());
+        if is_selector_text {
+            let (body_start, body_end, param_name, partial_key) = extract_selector_context(
                 arg_text,
-                arg_start_char,
                 arg_end_char,
                 arg_range.start.line,
                 character as usize,
                 key_separator,
-            )
-        {
+            );
             return Some(CompletionContext {
                 partial_key,
                 quote_context: QuoteContext::Selector { body_start, body_end, param_name },

--- a/src/ide/completion.rs
+++ b/src/ide/completion.rs
@@ -34,6 +34,9 @@ pub enum QuoteContext {
 
     /// Inside quotes (e.g., `t("|")` or `t("com|mon")`)
     InsideQuotes { key_start: Position, key_end: Position, partial_key: String },
+
+    /// Inside a selector arrow function (e.g., `t($ => $.common.|)`)
+    Selector { body_start: Position, body_end: Position, param_name: String },
 }
 
 #[derive(Debug, Clone)]
@@ -141,6 +144,23 @@ pub fn generate_completions(
                     new_text: insert_key.clone(),
                 }));
             }
+            QuoteContext::Selector { body_start, body_end, param_name } => {
+                // Convert key to member expression syntax: "a.b.c" → "$.a.b.c"
+                let member_key = if key_separator == "." {
+                    insert_key.clone()
+                } else {
+                    insert_key.split(key_separator).collect::<Vec<_>>().join(".")
+                };
+                let new_text = if member_key.is_empty() {
+                    param_name.clone()
+                } else {
+                    format!("{param_name}.{member_key}")
+                };
+                item.text_edit = Some(CompletionTextEdit::Edit(TextEdit {
+                    range: Range::new(*body_start, *body_end),
+                    new_text,
+                }));
+            }
         }
 
         completion_items.push(item);
@@ -149,6 +169,51 @@ pub fn generate_completions(
     completion_items.sort_by(|a, b| a.label.cmp(&b.label));
 
     completion_items
+}
+
+/// Extracts selector completion context from arrow function argument text.
+///
+/// Parses text like `$ => $.common.hello` and returns body positions, param name, and partial key.
+#[allow(clippy::cast_possible_truncation)]
+fn extract_selector_context(
+    arg_text: &str,
+    _arg_start_char: usize,
+    arg_end_char: usize,
+    arg_line: u32,
+    cursor_char: usize,
+    key_separator: &str,
+) -> Option<(Position, Position, String, String)> {
+    let arrow_pos = arg_text.find("=>")?;
+    let after_arrow = arg_text[arrow_pos + 2..].trim_start();
+    let body_start_char = arg_end_char - after_arrow.len();
+
+    let param_end = after_arrow.find(['.', '[']).unwrap_or(after_arrow.len());
+    let param_name = &after_arrow[..param_end];
+
+    let key_text_offset = if after_arrow.as_bytes().get(param_end) == Some(&b'.') {
+        param_end + 1
+    } else {
+        param_end
+    };
+
+    let key_start_char = body_start_char + key_text_offset;
+
+    let partial_key = if cursor_char >= key_start_char && cursor_char <= arg_end_char {
+        let raw = &arg_text[(arg_text.len() - (arg_end_char - key_start_char))
+            ..(arg_text.len() - (arg_end_char - cursor_char))];
+        if key_separator == "." {
+            raw.to_string()
+        } else {
+            raw.split('.').collect::<Vec<_>>().join(key_separator)
+        }
+    } else {
+        String::new()
+    };
+
+    let body_start = Position::new(arg_line, body_start_char as u32);
+    let body_end = Position::new(arg_line, arg_end_char as u32);
+
+    Some((body_start, body_end, param_name.to_string(), partial_key))
 }
 
 /// Extracts completion context using tree-sitter.
@@ -206,6 +271,24 @@ pub fn extract_completion_context_tree_sitter(
         }
 
         let arg_text = &arg_start_line[arg_start_char..arg_end_char];
+
+        // Selector API: t($ => $.common.hello) or t(($) => $.common.hello)
+        if arg_text.contains("=>")
+            && let Some((body_start, body_end, param_name, partial_key)) = extract_selector_context(
+                arg_text,
+                arg_start_char,
+                arg_end_char,
+                arg_range.start.line,
+                character as usize,
+                key_separator,
+            )
+        {
+            return Some(CompletionContext {
+                partial_key,
+                quote_context: QuoteContext::Selector { body_start, body_end, param_name },
+                key_prefix: call.key_prefix.clone(),
+            });
+        }
 
         let first_char = arg_text.chars().next()?;
 
@@ -934,5 +1017,127 @@ const msg = foo();
         let items = generate_completions(&db, &translations, None, &quote_context, None, None, ".");
 
         assert!(items.is_empty());
+    }
+
+    // ===== Selector API completion tests =====
+
+    #[rstest]
+    fn extract_completion_context_selector_basic() {
+        let text = r"
+const { t } = useTranslation();
+const msg = t($ => $.common.hello);
+";
+        //                 ^ col 14       ^ col 28
+        let language = ProgrammingLanguage::JavaScript;
+
+        // Line 2: const msg = t($ => $.common.hello);
+        // Cursor at col 28 = 'h' of 'hello', partial_key up to cursor = "common."
+        let result = extract_completion_context_tree_sitter(text, language, 2, 28, ".");
+
+        assert_that!(result.is_some(), eq(true));
+        let context = result.unwrap();
+        assert_that!(context.partial_key, eq("common."));
+        assert_that!(matches!(context.quote_context, QuoteContext::Selector { .. }), eq(true));
+    }
+
+    #[rstest]
+    fn extract_completion_context_selector_with_parens() {
+        let text = r"
+const { t } = useTranslation();
+const msg = t(($) => $.common.hello);
+";
+        let language = ProgrammingLanguage::JavaScript;
+
+        // ($) => $.common.hello
+        // Cursor somewhere inside the key portion
+        let result = extract_completion_context_tree_sitter(text, language, 2, 31, ".");
+
+        assert_that!(result.is_some(), eq(true));
+        let context = result.unwrap();
+        assert_that!(context.partial_key, eq("common.h"));
+        assert_that!(matches!(context.quote_context, QuoteContext::Selector { .. }), eq(true));
+    }
+
+    #[rstest]
+    fn generate_completions_selector_text_edit() {
+        let db = I18nDatabaseImpl::default();
+        let en_translation = Translation::new(
+            &db,
+            "en".to_string(),
+            None,
+            "/test/en.json".to_string(),
+            HashMap::from([("common.hello".to_string(), "Hello".to_string())]),
+            "{}".to_string(),
+            HashMap::new(),
+            HashMap::new(),
+        );
+
+        let translations = vec![en_translation];
+        let body_start = Position::new(1, 10);
+        let body_end = Position::new(1, 20);
+        let quote_context =
+            QuoteContext::Selector { body_start, body_end, param_name: "$".to_string() };
+
+        let items = generate_completions(
+            &db,
+            &translations,
+            Some("common."),
+            &quote_context,
+            None,
+            None,
+            ".",
+        );
+
+        assert_eq!(items.len(), 1);
+
+        // Selector inserts member expression: $.common.hello
+        if let Some(CompletionTextEdit::Edit(edit)) = &items[0].text_edit {
+            assert_eq!(edit.new_text, "$.common.hello");
+            assert_eq!(edit.range.start, body_start);
+            assert_eq!(edit.range.end, body_end);
+        } else {
+            panic!("Expected TextEdit");
+        }
+    }
+
+    #[rstest]
+    fn generate_completions_selector_with_key_prefix() {
+        let db = I18nDatabaseImpl::default();
+        let en_translation = Translation::new(
+            &db,
+            "en".to_string(),
+            None,
+            "/test/en.json".to_string(),
+            HashMap::from([("common.hello".to_string(), "Hello".to_string())]),
+            "{}".to_string(),
+            HashMap::new(),
+            HashMap::new(),
+        );
+
+        let translations = vec![en_translation];
+        let body_start = Position::new(1, 10);
+        let body_end = Position::new(1, 15);
+        let quote_context =
+            QuoteContext::Selector { body_start, body_end, param_name: "$".to_string() };
+
+        // With keyPrefix "common", insert_key becomes "hello"
+        let items = generate_completions(
+            &db,
+            &translations,
+            None,
+            &quote_context,
+            Some("common"),
+            None,
+            ".",
+        );
+
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].label, "hello");
+
+        if let Some(CompletionTextEdit::Edit(edit)) = &items[0].text_edit {
+            assert_eq!(edit.new_text, "$.hello");
+        } else {
+            panic!("Expected TextEdit");
+        }
     }
 }

--- a/src/ide/completion.rs
+++ b/src/ide/completion.rs
@@ -1022,6 +1022,27 @@ const msg = foo();
     // ===== Selector API completion tests =====
 
     #[rstest]
+    fn extract_completion_context_selector_trailing_dot() {
+        // t($ => $.common.|)  — cursor right after the trailing dot
+        //                  ^ completion should trigger here
+        let text = r"
+const { t } = useTranslation();
+const msg = t($ => $.common.);
+";
+        let language = ProgrammingLanguage::JavaScript;
+
+        // Line 2: const msg = t($ => $.common.);
+        //                       ^14        ^27=. ^28=)
+        // The extended selector range includes the trailing '.', so cursor at col 28 is within range.
+        let result = extract_completion_context_tree_sitter(text, language, 2, 28, ".");
+
+        assert_that!(result.is_some(), eq(true));
+        let context = result.unwrap();
+        assert_that!(context.partial_key, eq("common."));
+        assert_that!(matches!(context.quote_context, QuoteContext::Selector { .. }), eq(true));
+    }
+
+    #[rstest]
     fn extract_completion_context_selector_basic() {
         let text = r"
 const { t } = useTranslation();

--- a/src/ide/completion.rs
+++ b/src/ide/completion.rs
@@ -1382,4 +1382,162 @@ const msg = t(($) => $.common.hello);
             panic!("Expected TextEdit");
         }
     }
+
+    #[rstest]
+    fn generate_completions_selector_non_dot_separator() {
+        let db = I18nDatabaseImpl::default();
+        let en_translation = Translation::new(
+            &db,
+            "en".to_string(),
+            None,
+            "/test/en.json".to_string(),
+            HashMap::from([("common_hello".to_string(), "Hello".to_string())]),
+            "{}".to_string(),
+            HashMap::new(),
+            HashMap::new(),
+        );
+
+        let translations = vec![en_translation];
+        let body_start = Position::new(1, 10);
+        let body_end = Position::new(1, 25);
+        let quote_context =
+            QuoteContext::Selector { body_start, body_end, param_name: "$".to_string() };
+
+        // key_separator="_" → insert_key is "common_hello", converted to "$.common.hello"
+        let items = generate_completions(
+            &db,
+            &translations,
+            &CompletionOptions {
+                partial_key: None,
+                quote_context: &quote_context,
+                key_prefix: None,
+                effective_language: None,
+                key_separator: "_",
+                prefer_selector: false,
+            },
+        );
+
+        assert_eq!(items.len(), 1);
+        if let Some(CompletionTextEdit::Edit(edit)) = &items[0].text_edit {
+            assert_eq!(edit.new_text, "$.common.hello");
+        } else {
+            panic!("Expected TextEdit");
+        }
+    }
+
+    #[rstest]
+    fn generate_completions_selector_empty_key() {
+        let db = I18nDatabaseImpl::default();
+        let en_translation = Translation::new(
+            &db,
+            "en".to_string(),
+            None,
+            "/test/en.json".to_string(),
+            HashMap::from([(String::new(), "Root".to_string())]),
+            "{}".to_string(),
+            HashMap::new(),
+            HashMap::new(),
+        );
+
+        let translations = vec![en_translation];
+        let body_start = Position::new(1, 10);
+        let body_end = Position::new(1, 11);
+        let quote_context =
+            QuoteContext::Selector { body_start, body_end, param_name: "$".to_string() };
+
+        let items = generate_completions(
+            &db,
+            &translations,
+            &CompletionOptions {
+                partial_key: None,
+                quote_context: &quote_context,
+                key_prefix: None,
+                effective_language: None,
+                key_separator: ".",
+                prefer_selector: false,
+            },
+        );
+
+        assert_eq!(items.len(), 1);
+        if let Some(CompletionTextEdit::Edit(edit)) = &items[0].text_edit {
+            // Empty key → just the param name
+            assert_eq!(edit.new_text, "$");
+        } else {
+            panic!("Expected TextEdit");
+        }
+    }
+
+    #[rstest]
+    fn generate_completions_no_quotes_prefer_selector_non_dot_separator() {
+        let db = I18nDatabaseImpl::default();
+        let en_translation = Translation::new(
+            &db,
+            "en".to_string(),
+            None,
+            "/test/en.json".to_string(),
+            HashMap::from([("common_hello".to_string(), "Hello".to_string())]),
+            "{}".to_string(),
+            HashMap::new(),
+            HashMap::new(),
+        );
+
+        let translations = vec![en_translation];
+        let position = Position::new(1, 5);
+        let quote_context = QuoteContext::NoQuotes { position };
+
+        // prefer_selector + non-dot separator → "common_hello" → "($) => $.common.hello"
+        let items = generate_completions(
+            &db,
+            &translations,
+            &CompletionOptions {
+                partial_key: None,
+                quote_context: &quote_context,
+                key_prefix: None,
+                effective_language: None,
+                key_separator: "_",
+                prefer_selector: true,
+            },
+        );
+
+        assert_eq!(items.len(), 1);
+        if let Some(CompletionTextEdit::Edit(edit)) = &items[0].text_edit {
+            assert_eq!(edit.new_text, "($) => $.common.hello");
+        } else {
+            panic!("Expected TextEdit");
+        }
+    }
+
+    #[rstest]
+    fn extract_completion_context_selector_body_only() {
+        // When arg_key_range is body-only (no `=>`), selector detection still works
+        let text = r"
+const { t } = useTranslation();
+const msg = t($ => $.common.hello);
+";
+        let language = ProgrammingLanguage::JavaScript;
+
+        // Cursor on `hello` (col 21 = 'h' of hello)
+        let result = extract_completion_context_tree_sitter(text, language, 2, 21, ".");
+
+        assert_that!(result.is_some(), eq(true));
+        let context = result.unwrap();
+        assert_that!(matches!(context.quote_context, QuoteContext::Selector { .. }), eq(true));
+    }
+
+    #[rstest]
+    fn extract_completion_context_selector_non_dot_separator() {
+        let text = r"
+const { t } = useTranslation();
+const msg = t($ => $.common.hello);
+";
+        let language = ProgrammingLanguage::JavaScript;
+
+        // With key_separator="_", member `.` maps to `_` in partial key
+        // Cursor at col 28 ('h' of hello), partial = "common_" (member `.` → separator `_`)
+        let result = extract_completion_context_tree_sitter(text, language, 2, 28, "_");
+
+        assert_that!(result.is_some(), eq(true));
+        let context = result.unwrap();
+        assert_that!(context.partial_key, eq("common_"));
+    }
 }

--- a/src/ide/completion.rs
+++ b/src/ide/completion.rs
@@ -46,16 +46,77 @@ pub struct CompletionContext {
     pub key_prefix: Option<String>,
 }
 
+/// Options for `generate_completions`.
+pub struct CompletionOptions<'a> {
+    pub partial_key: Option<&'a str>,
+    pub quote_context: &'a QuoteContext,
+    pub key_prefix: Option<&'a str>,
+    pub effective_language: Option<&'a str>,
+    pub key_separator: &'a str,
+    pub prefer_selector: bool,
+}
+
+/// Creates the text edit for a completion item based on the quote context.
+fn build_text_edit(
+    insert_key: &str,
+    quote_context: &QuoteContext,
+    key_separator: &str,
+    prefer_selector: bool,
+) -> CompletionTextEdit {
+    match quote_context {
+        QuoteContext::NoQuotes { position } => {
+            let new_text = if prefer_selector {
+                let member_key = if key_separator == "." {
+                    insert_key.to_string()
+                } else {
+                    insert_key.split(key_separator).collect::<Vec<_>>().join(".")
+                };
+                format!("($) => $.{member_key}")
+            } else {
+                format!("\"{insert_key}\"")
+            };
+            CompletionTextEdit::Edit(TextEdit { range: Range::new(*position, *position), new_text })
+        }
+        QuoteContext::InsideQuotes { key_start, key_end, .. } => {
+            CompletionTextEdit::Edit(TextEdit {
+                range: Range::new(*key_start, *key_end),
+                new_text: insert_key.to_string(),
+            })
+        }
+        QuoteContext::Selector { body_start, body_end, param_name } => {
+            let member_key = if key_separator == "." {
+                insert_key.to_string()
+            } else {
+                insert_key.split(key_separator).collect::<Vec<_>>().join(".")
+            };
+            let new_text = if member_key.is_empty() {
+                param_name.clone()
+            } else {
+                format!("{param_name}.{member_key}")
+            };
+            CompletionTextEdit::Edit(TextEdit {
+                range: Range::new(*body_start, *body_end),
+                new_text,
+            })
+        }
+    }
+}
+
 /// Generates completion items for translation keys.
 pub fn generate_completions(
     db: &dyn I18nDatabase,
     translations: &[Translation],
-    partial_key: Option<&str>,
-    quote_context: &QuoteContext,
-    key_prefix: Option<&str>,
-    effective_language: Option<&str>,
-    key_separator: &str,
+    opts: &CompletionOptions<'_>,
 ) -> Vec<CompletionItem> {
+    let CompletionOptions {
+        partial_key,
+        quote_context,
+        key_prefix,
+        effective_language,
+        key_separator,
+        prefer_selector,
+    } = opts;
+
     let mut completion_items = Vec::new();
     let mut key_translations: HashMap<String, Vec<(String, String)>> = HashMap::new();
 
@@ -130,38 +191,8 @@ pub fn generate_completions(
             ..Default::default()
         };
 
-        match quote_context {
-            QuoteContext::NoQuotes { position } => {
-                let new_text = format!("\"{insert_key}\"");
-                item.text_edit = Some(CompletionTextEdit::Edit(TextEdit {
-                    range: Range::new(*position, *position),
-                    new_text,
-                }));
-            }
-            QuoteContext::InsideQuotes { key_start, key_end, .. } => {
-                item.text_edit = Some(CompletionTextEdit::Edit(TextEdit {
-                    range: Range::new(*key_start, *key_end),
-                    new_text: insert_key.clone(),
-                }));
-            }
-            QuoteContext::Selector { body_start, body_end, param_name } => {
-                // Convert key to member expression syntax: "a.b.c" → "$.a.b.c"
-                let member_key = if key_separator == "." {
-                    insert_key.clone()
-                } else {
-                    insert_key.split(key_separator).collect::<Vec<_>>().join(".")
-                };
-                let new_text = if member_key.is_empty() {
-                    param_name.clone()
-                } else {
-                    format!("{param_name}.{member_key}")
-                };
-                item.text_edit = Some(CompletionTextEdit::Edit(TextEdit {
-                    range: Range::new(*body_start, *body_end),
-                    new_text,
-                }));
-            }
-        }
+        item.text_edit =
+            Some(build_text_edit(&insert_key, quote_context, key_separator, *prefer_selector));
 
         completion_items.push(item);
     }
@@ -381,7 +412,18 @@ mod tests {
             key_end: Position::new(0, 0),
             partial_key: String::new(),
         };
-        let items = generate_completions(&db, &translations, None, &quote_context, None, None, ".");
+        let items = generate_completions(
+            &db,
+            &translations,
+            &CompletionOptions {
+                partial_key: None,
+                quote_context: &quote_context,
+                key_prefix: None,
+                effective_language: None,
+                key_separator: ".",
+                prefer_selector: false,
+            },
+        );
 
         assert_that!(items.len(), eq(3));
         assert_that!(items[0].label, eq("common.goodbye"));
@@ -417,11 +459,14 @@ mod tests {
         let items = generate_completions(
             &db,
             &translations,
-            Some("common."),
-            &quote_context,
-            None,
-            None,
-            ".",
+            &CompletionOptions {
+                partial_key: Some("common."),
+                quote_context: &quote_context,
+                key_prefix: None,
+                effective_language: None,
+                key_separator: ".",
+                prefer_selector: false,
+            },
         );
 
         assert_that!(items.len(), eq(2));
@@ -462,7 +507,18 @@ mod tests {
             key_end: Position::new(0, 0),
             partial_key: String::new(),
         };
-        let items = generate_completions(&db, &translations, None, &quote_context, None, None, ".");
+        let items = generate_completions(
+            &db,
+            &translations,
+            &CompletionOptions {
+                partial_key: None,
+                quote_context: &quote_context,
+                key_prefix: None,
+                effective_language: None,
+                key_separator: ".",
+                prefer_selector: false,
+            },
+        );
 
         // Should have one item with both languages
         assert_that!(items.len(), eq(1));
@@ -501,11 +557,14 @@ mod tests {
         let items = generate_completions(
             &db,
             &translations,
-            Some("nonexistent."),
-            &quote_context,
-            None,
-            None,
-            ".",
+            &CompletionOptions {
+                partial_key: Some("nonexistent."),
+                quote_context: &quote_context,
+                key_prefix: None,
+                effective_language: None,
+                key_separator: ".",
+                prefer_selector: false,
+            },
         );
 
         assert_that!(items, is_empty());
@@ -747,11 +806,14 @@ const msg = foo();
         let items = generate_completions(
             &db,
             &translations,
-            None,
-            &quote_context,
-            Some("common"),
-            None,
-            ".",
+            &CompletionOptions {
+                partial_key: None,
+                quote_context: &quote_context,
+                key_prefix: Some("common"),
+                effective_language: None,
+                key_separator: ".",
+                prefer_selector: false,
+            },
         );
 
         assert_eq!(items.len(), 2);
@@ -787,11 +849,14 @@ const msg = foo();
         let items = generate_completions(
             &db,
             &translations,
-            Some("hel"),
-            &quote_context,
-            Some("common"),
-            None,
-            ".",
+            &CompletionOptions {
+                partial_key: Some("hel"),
+                quote_context: &quote_context,
+                key_prefix: Some("common"),
+                effective_language: None,
+                key_separator: ".",
+                prefer_selector: false,
+            },
         );
 
         assert_eq!(items.len(), 2);
@@ -824,11 +889,14 @@ const msg = foo();
         let items = generate_completions(
             &db,
             &translations,
-            None,
-            &quote_context,
-            Some("errors"),
-            None,
-            ".",
+            &CompletionOptions {
+                partial_key: None,
+                quote_context: &quote_context,
+                key_prefix: Some("errors"),
+                effective_language: None,
+                key_separator: ".",
+                prefer_selector: false,
+            },
         );
 
         assert_eq!(items.len(), 1);
@@ -866,8 +934,18 @@ const msg = foo();
             partial_key: String::new(),
         };
 
-        let items =
-            generate_completions(&db, &translations, None, &quote_context, None, Some("ja"), ".");
+        let items = generate_completions(
+            &db,
+            &translations,
+            &CompletionOptions {
+                partial_key: None,
+                quote_context: &quote_context,
+                key_prefix: None,
+                effective_language: Some("ja"),
+                key_separator: ".",
+                prefer_selector: false,
+            },
+        );
 
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].detail, Some("こんにちは".to_string()));
@@ -894,8 +972,18 @@ const msg = foo();
             partial_key: String::new(),
         };
 
-        let items =
-            generate_completions(&db, &translations, None, &quote_context, None, Some("fr"), ".");
+        let items = generate_completions(
+            &db,
+            &translations,
+            &CompletionOptions {
+                partial_key: None,
+                quote_context: &quote_context,
+                key_prefix: None,
+                effective_language: Some("fr"),
+                key_separator: ".",
+                prefer_selector: false,
+            },
+        );
 
         assert_eq!(items.len(), 1);
         assert!(items[0].detail.is_none());
@@ -922,8 +1010,18 @@ const msg = foo();
             partial_key: String::new(),
         };
 
-        let items =
-            generate_completions(&db, &translations, None, &quote_context, None, Some("en"), ".");
+        let items = generate_completions(
+            &db,
+            &translations,
+            &CompletionOptions {
+                partial_key: None,
+                quote_context: &quote_context,
+                key_prefix: None,
+                effective_language: Some("en"),
+                key_separator: ".",
+                prefer_selector: false,
+            },
+        );
 
         assert_eq!(items.len(), 1);
         let item = &items[0];
@@ -955,7 +1053,18 @@ const msg = foo();
         let position = Position::new(1, 5);
         let quote_context = QuoteContext::NoQuotes { position };
 
-        let items = generate_completions(&db, &translations, None, &quote_context, None, None, ".");
+        let items = generate_completions(
+            &db,
+            &translations,
+            &CompletionOptions {
+                partial_key: None,
+                quote_context: &quote_context,
+                key_prefix: None,
+                effective_language: None,
+                key_separator: ".",
+                prefer_selector: false,
+            },
+        );
 
         assert_eq!(items.len(), 1);
 
@@ -989,8 +1098,18 @@ const msg = foo();
         let quote_context =
             QuoteContext::InsideQuotes { key_start, key_end, partial_key: "hel".to_string() };
 
-        let items =
-            generate_completions(&db, &translations, Some("hel"), &quote_context, None, None, ".");
+        let items = generate_completions(
+            &db,
+            &translations,
+            &CompletionOptions {
+                partial_key: Some("hel"),
+                quote_context: &quote_context,
+                key_prefix: None,
+                effective_language: None,
+                key_separator: ".",
+                prefer_selector: false,
+            },
+        );
 
         assert_eq!(items.len(), 1);
 
@@ -1014,7 +1133,18 @@ const msg = foo();
             partial_key: String::new(),
         };
 
-        let items = generate_completions(&db, &translations, None, &quote_context, None, None, ".");
+        let items = generate_completions(
+            &db,
+            &translations,
+            &CompletionOptions {
+                partial_key: None,
+                quote_context: &quote_context,
+                key_prefix: None,
+                effective_language: None,
+                key_separator: ".",
+                prefer_selector: false,
+            },
+        );
 
         assert!(items.is_empty());
     }
@@ -1102,11 +1232,14 @@ const msg = t(($) => $.common.hello);
         let items = generate_completions(
             &db,
             &translations,
-            Some("common."),
-            &quote_context,
-            None,
-            None,
-            ".",
+            &CompletionOptions {
+                partial_key: Some("common."),
+                quote_context: &quote_context,
+                key_prefix: None,
+                effective_language: None,
+                key_separator: ".",
+                prefer_selector: false,
+            },
         );
 
         assert_eq!(items.len(), 1);
@@ -1145,11 +1278,14 @@ const msg = t(($) => $.common.hello);
         let items = generate_completions(
             &db,
             &translations,
-            None,
-            &quote_context,
-            Some("common"),
-            None,
-            ".",
+            &CompletionOptions {
+                partial_key: None,
+                quote_context: &quote_context,
+                key_prefix: Some("common"),
+                effective_language: None,
+                key_separator: ".",
+                prefer_selector: false,
+            },
         );
 
         assert_eq!(items.len(), 1);
@@ -1157,6 +1293,91 @@ const msg = t(($) => $.common.hello);
 
         if let Some(CompletionTextEdit::Edit(edit)) = &items[0].text_edit {
             assert_eq!(edit.new_text, "$.hello");
+        } else {
+            panic!("Expected TextEdit");
+        }
+    }
+
+    #[rstest]
+    fn generate_completions_no_quotes_prefer_selector() {
+        let db = I18nDatabaseImpl::default();
+        let en_translation = Translation::new(
+            &db,
+            "en".to_string(),
+            None,
+            "/test/en.json".to_string(),
+            HashMap::from([("common.hello".to_string(), "Hello".to_string())]),
+            "{}".to_string(),
+            HashMap::new(),
+            HashMap::new(),
+        );
+
+        let translations = vec![en_translation];
+        let position = Position::new(1, 5);
+        let quote_context = QuoteContext::NoQuotes { position };
+
+        // prefer_selector = true → inserts selector format
+        let items = generate_completions(
+            &db,
+            &translations,
+            &CompletionOptions {
+                partial_key: None,
+                quote_context: &quote_context,
+                key_prefix: None,
+                effective_language: None,
+                key_separator: ".",
+                prefer_selector: true,
+            },
+        );
+
+        assert_eq!(items.len(), 1);
+
+        if let Some(CompletionTextEdit::Edit(edit)) = &items[0].text_edit {
+            assert_eq!(edit.new_text, "($) => $.common.hello");
+            assert_eq!(edit.range.start, position);
+            assert_eq!(edit.range.end, position);
+        } else {
+            panic!("Expected TextEdit");
+        }
+    }
+
+    #[rstest]
+    fn generate_completions_no_quotes_prefer_selector_with_key_prefix() {
+        let db = I18nDatabaseImpl::default();
+        let en_translation = Translation::new(
+            &db,
+            "en".to_string(),
+            None,
+            "/test/en.json".to_string(),
+            HashMap::from([("common.hello".to_string(), "Hello".to_string())]),
+            "{}".to_string(),
+            HashMap::new(),
+            HashMap::new(),
+        );
+
+        let translations = vec![en_translation];
+        let position = Position::new(1, 5);
+        let quote_context = QuoteContext::NoQuotes { position };
+
+        // With keyPrefix "common", insert_key becomes "hello"
+        let items = generate_completions(
+            &db,
+            &translations,
+            &CompletionOptions {
+                partial_key: None,
+                quote_context: &quote_context,
+                key_prefix: Some("common"),
+                effective_language: None,
+                key_separator: ".",
+                prefer_selector: true,
+            },
+        );
+
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].label, "hello");
+
+        if let Some(CompletionTextEdit::Edit(edit)) = &items[0].text_edit {
+            assert_eq!(edit.new_text, "($) => $.hello");
         } else {
             panic!("Expected TextEdit");
         }

--- a/src/ide/handlers/features.rs
+++ b/src/ide/handlers/features.rs
@@ -40,9 +40,11 @@ pub async fn handle_completion(
     };
 
     // Acquire config before db to respect lock ordering (config_manager → db → source_files)
-    let (key_separator, primary_languages) = {
+    let (key_separator, primary_languages, prefer_selector) = {
         let settings = backend.config_manager.lock().await.get_settings().clone();
-        (settings.key_separator, settings.primary_languages)
+        let prefer_selector =
+            settings.frameworks.i18next.as_ref().is_some_and(|c| c.prefer_selector);
+        (settings.key_separator, settings.primary_languages, prefer_selector)
     };
 
     // Acquire db before source_files to prevent stale IDs after reset_state()
@@ -96,11 +98,14 @@ pub async fn handle_completion(
     let items = crate::ide::completion::generate_completions(
         &*db,
         &translations,
-        partial_key_opt,
-        &context.quote_context,
-        context.key_prefix.as_deref(),
-        effective_language.as_deref(),
-        &key_separator,
+        &crate::ide::completion::CompletionOptions {
+            partial_key: partial_key_opt,
+            quote_context: &context.quote_context,
+            key_prefix: context.key_prefix.as_deref(),
+            effective_language: effective_language.as_deref(),
+            key_separator: &key_separator,
+            prefer_selector,
+        },
     );
     drop(db);
     drop(translations);

--- a/src/syntax/analyzer/extractor.rs
+++ b/src/syntax/analyzer/extractor.rs
@@ -275,7 +275,9 @@ pub fn analyze_trans_fn_calls(
                         |prefix| format!("{}{}{}", prefix, key_separator, &call_trans_fn.key),
                     ),
                     arg_key: call_trans_fn.key.clone(),
-                    arg_key_node: get_node_range(arg_key_node),
+                    arg_key_node: call_trans_fn
+                        .arg_key_range
+                        .unwrap_or_else(|| get_node_range(arg_key_node)),
                     key_prefix,
                     namespace,
                     namespaces,
@@ -391,6 +393,23 @@ fn extract_selector_key_parts(
         }
         _ => None,
     }
+}
+
+/// Extends a node's range to include trailing accessor operators (`.` or `[`).
+///
+/// Tree-sitter excludes trailing accessors from incomplete expressions like `$.common.`,
+/// so we scan the source bytes and extend the range to cover them.
+#[allow(clippy::cast_possible_truncation)]
+fn extend_range_past_accessors(node: Node<'_>, source_bytes: &[u8]) -> Range {
+    let mut range = get_node_range(node);
+    let mut byte = node.end_byte();
+    while source_bytes.get(byte).is_some_and(|&b| matches!(b, b'.' | b'[')) {
+        byte += 1;
+    }
+    if byte > node.end_byte() {
+        range.end.character += (byte - node.end_byte()) as u32;
+    }
+    range
 }
 
 /// Extracts a translation key from a selector arrow function node.
@@ -588,12 +607,17 @@ fn parse_call_trans_fn_captures<'a>(
         let selector_key =
             extract_selector_key(selector_node, source_bytes, key_separator).unwrap_or_default();
 
+        // Extend the range past trailing accessor operators (`.` or `[`) that tree-sitter
+        // excludes from the arrow function node for incomplete expressions like `$ => $.common.`
+        let extended_range = extend_range_past_accessors(selector_node, source_bytes);
+
         return Ok(CallTransFnDetail {
             trans_fn_name: trans_fn_name.unwrap_or_else(|| "t".to_string()),
             key: selector_key,
             key_node: selector_node,
             arg_key_node: selector_node,
             explicit_namespace,
+            arg_key_range: Some(extended_range),
         });
     }
 
@@ -621,6 +645,7 @@ fn parse_call_trans_fn_captures<'a>(
         key_node: key_node.unwrap_or(arg_key_node),
         arg_key_node,
         explicit_namespace,
+        arg_key_range: None,
     })
 }
 
@@ -1856,6 +1881,22 @@ function Component() {
     }
 
     // ===== Selector API tests =====
+
+    #[rstest]
+    fn test_selector_api_incomplete_trailing_dot(queries: Vec<Query>, js_lang: Language) {
+        // Incomplete selector: trailing dot (mid-typing scenario for completion)
+        let code = r"
+            const { t } = useTranslation();
+            const msg = t($ => $.common.);
+        ";
+
+        let calls =
+            analyze_trans_fn_calls(code, &js_lang, ProgrammingLanguage::JavaScript, &queries, ".")
+                .unwrap();
+
+        // Should produce a TransFnCall (possibly with partial key) for completion support
+        assert_that!(calls.len(), ge(1));
+    }
 
     #[rstest]
     fn test_selector_api_basic(queries: Vec<Query>, js_lang: Language) {

--- a/src/syntax/analyzer/extractor.rs
+++ b/src/syntax/analyzer/extractor.rs
@@ -194,6 +194,11 @@ pub fn analyze_trans_fn_calls(
         })
     });
 
+    // Deduplicate captures at the same position with the same type from the same query.
+    // Multiple query patterns (e.g., string-based and selector-based t() calls) can match
+    // the same node, producing duplicate CallTransFn entries.
+    all_captures.dedup_by(|a, b| a.1 == b.1 && a.3 == b.3 && a.0 == b.0);
+
     for (query_idx, capture_name, node, _) in all_captures {
         let Some(query) = queries.get(query_idx) else {
             continue;
@@ -217,9 +222,13 @@ pub fn analyze_trans_fn_calls(
                 scopes.push_scope(trans_fn_name, ScopeInfo::new(scope_node, trans_fn));
             }
             CaptureName::CallTransFn => {
-                let Ok(call_trans_fn) =
-                    parse_call_trans_fn_captures(query, node, source_bytes, cap_names)
-                else {
+                let Ok(call_trans_fn) = parse_call_trans_fn_captures(
+                    query,
+                    node,
+                    source_bytes,
+                    cap_names,
+                    key_separator,
+                ) else {
                     continue;
                 };
 
@@ -294,6 +303,99 @@ pub fn parse_key_with_namespace(
         || (None, key.to_string()),
         |(ns, key_part)| (Some(ns.to_string()), key_part.to_string()),
     )
+}
+
+/// Extracts the parameter name from an arrow function node.
+///
+/// Handles both `$ => ...` (`parameter` field) and `($) => ...` (`parameters`/`formal_parameters` field).
+/// In TypeScript/TSX, parameters are wrapped in `required_parameter` nodes.
+fn extract_arrow_param_name(arrow_fn: Node<'_>, source_bytes: &[u8]) -> Option<String> {
+    // `$ => ...` — single identifier parameter (JS only)
+    if let Some(param) = arrow_fn.child_by_field_name("parameter")
+        && param.kind() == "identifier"
+    {
+        return extract_node_text(param, source_bytes);
+    }
+    // `($) => ...` — formal_parameters wrapping an identifier or required_parameter
+    if let Some(params) = arrow_fn.child_by_field_name("parameters")
+        && params.kind() == "formal_parameters"
+    {
+        for i in 0..params.named_child_count() {
+            #[allow(clippy::cast_possible_truncation)]
+            if let Some(child) = params.named_child(i as u32) {
+                match child.kind() {
+                    // JavaScript: (identifier)
+                    "identifier" => return extract_node_text(child, source_bytes),
+                    // TypeScript/TSX: (required_parameter pattern: (identifier))
+                    "required_parameter" => {
+                        if let Some(pattern) = child.child_by_field_name("pattern")
+                            && pattern.kind() == "identifier"
+                        {
+                            return extract_node_text(pattern, source_bytes);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Recursively extracts key segments from a selector expression body.
+///
+/// Walks the `member_expression` / `subscript_expression` chain and collects property names.
+/// Returns `None` if the chain doesn't start with the expected parameter.
+fn extract_selector_key_parts(
+    node: Node<'_>,
+    param_name: &str,
+    source_bytes: &[u8],
+) -> Option<Vec<String>> {
+    match node.kind() {
+        "identifier" => {
+            // Terminal: should be the parameter (e.g., `$`)
+            let name = node.utf8_text(source_bytes).ok()?;
+            if name == param_name { Some(Vec::new()) } else { None }
+        }
+        "member_expression" => {
+            let object = node.child_by_field_name("object")?;
+            let property = node.child_by_field_name("property")?;
+            let prop_text = property.utf8_text(source_bytes).ok()?.to_string();
+            let mut parts = extract_selector_key_parts(object, param_name, source_bytes)?;
+            parts.push(prop_text);
+            Some(parts)
+        }
+        "subscript_expression" => {
+            let object = node.child_by_field_name("object")?;
+            let index = node.child_by_field_name("index")?;
+            let index_text = match index.kind() {
+                "number" => index.utf8_text(source_bytes).ok()?.to_string(),
+                "string" => {
+                    // Extract the fragment inside quotes
+                    index.named_child(0)?.utf8_text(source_bytes).ok()?.to_string()
+                }
+                _ => return None,
+            };
+            let mut parts = extract_selector_key_parts(object, param_name, source_bytes)?;
+            parts.push(index_text);
+            Some(parts)
+        }
+        _ => None,
+    }
+}
+
+/// Extracts a translation key from a selector arrow function node.
+///
+/// Parses `$ => $.a.b.c` into the key `"a.b.c"` using the given key separator.
+fn extract_selector_key(
+    arrow_fn: Node<'_>,
+    source_bytes: &[u8],
+    key_separator: &str,
+) -> Option<String> {
+    let param_name = extract_arrow_param_name(arrow_fn, source_bytes)?;
+    let body = arrow_fn.child_by_field_name("body")?;
+    let parts = extract_selector_key_parts(body, &param_name, source_bytes)?;
+    Some(parts.join(key_separator))
 }
 
 /// Extracts string arguments from an arguments node
@@ -421,6 +523,7 @@ fn parse_call_trans_fn_captures<'a>(
     capture_node: Node<'a>,
     source_bytes: &[u8],
     cap_names: &[&str],
+    key_separator: &str,
 ) -> Result<CallTransFnDetail<'a>, AnalyzerError> {
     let mut trans_fn_name: Option<String> = None;
     let mut key: Option<String> = None;
@@ -428,6 +531,7 @@ fn parse_call_trans_fn_captures<'a>(
     let mut key_arg_node: Option<Node<'a>> = None;
     let mut trans_args_node: Option<Node<'a>> = None;
     let mut explicit_namespace: Option<String> = None;
+    let mut selector_fn_node: Option<Node<'a>> = None;
 
     let mut cursor = QueryCursor::new();
     let mut matches = cursor.matches(query, capture_node, source_bytes);
@@ -461,9 +565,26 @@ fn parse_call_trans_fn_captures<'a>(
                     // The ns value from t("key", { ns: "common" })
                     explicit_namespace = extract_node_text(capture.node, source_bytes);
                 }
+                CaptureName::SelectorFn => {
+                    selector_fn_node = Some(capture.node);
+                }
                 _ => {}
             }
         }
+    }
+
+    // Handle Selector API: t($ => $.a.b.c)
+    if let Some(selector_node) = selector_fn_node {
+        let selector_key = extract_selector_key(selector_node, source_bytes, key_separator)
+            .ok_or(AnalyzerError::ParseFailed)?;
+
+        return Ok(CallTransFnDetail {
+            trans_fn_name: trans_fn_name.unwrap_or_else(|| "t".to_string()),
+            key: selector_key,
+            key_node: selector_node,
+            arg_key_node: selector_node,
+            explicit_namespace,
+        });
     }
 
     // Determine the argument node: use string argument if available, otherwise check for empty args
@@ -1722,5 +1843,211 @@ function Component() {
         )
         .unwrap();
         assert_that!(calls, is_empty());
+    }
+
+    // ===== Selector API tests =====
+
+    #[rstest]
+    fn test_selector_api_basic(queries: Vec<Query>, js_lang: Language) {
+        let code = r"
+            const { t } = useTranslation();
+            const message = t($ => $.my.nested.key);
+        ";
+
+        let calls =
+            analyze_trans_fn_calls(code, &js_lang, ProgrammingLanguage::JavaScript, &queries, ".")
+                .unwrap();
+
+        assert_that!(
+            calls,
+            elements_are![all![
+                field!(TransFnCall.key, eq("my.nested.key")),
+                field!(TransFnCall.arg_key, eq("my.nested.key"))
+            ]]
+        );
+    }
+
+    #[rstest]
+    fn test_selector_api_with_parens(queries: Vec<Query>, js_lang: Language) {
+        let code = r"
+            const { t } = useTranslation();
+            const message = t(($) => $.my.key);
+        ";
+
+        let calls =
+            analyze_trans_fn_calls(code, &js_lang, ProgrammingLanguage::JavaScript, &queries, ".")
+                .unwrap();
+
+        assert_that!(calls, elements_are![field!(TransFnCall.key, eq("my.key"))]);
+    }
+
+    #[rstest]
+    fn test_selector_api_single_key(queries: Vec<Query>, js_lang: Language) {
+        let code = r"
+            const { t } = useTranslation();
+            const message = t($ => $.hello);
+        ";
+
+        let calls =
+            analyze_trans_fn_calls(code, &js_lang, ProgrammingLanguage::JavaScript, &queries, ".")
+                .unwrap();
+
+        assert_that!(calls, elements_are![field!(TransFnCall.key, eq("hello"))]);
+    }
+
+    #[rstest]
+    fn test_selector_api_with_namespace(queries: Vec<Query>, js_lang: Language) {
+        let code = r#"
+            const { t } = useTranslation("common");
+            const message = t($ => $.greeting);
+        "#;
+
+        let calls =
+            analyze_trans_fn_calls(code, &js_lang, ProgrammingLanguage::JavaScript, &queries, ".")
+                .unwrap();
+
+        assert_that!(
+            calls,
+            elements_are![all![
+                field!(TransFnCall.key, eq("greeting")),
+                field!(TransFnCall.namespace, some(eq("common")))
+            ]]
+        );
+    }
+
+    #[rstest]
+    fn test_selector_api_with_explicit_namespace(queries: Vec<Query>, js_lang: Language) {
+        let code = r#"
+            const { t } = useTranslation("common");
+            const message = t($ => $.hello, { ns: "errors" });
+        "#;
+
+        let calls =
+            analyze_trans_fn_calls(code, &js_lang, ProgrammingLanguage::JavaScript, &queries, ".")
+                .unwrap();
+
+        assert_that!(
+            calls,
+            elements_are![all![
+                field!(TransFnCall.key, eq("hello")),
+                field!(TransFnCall.namespace, some(eq("errors")))
+            ]]
+        );
+    }
+
+    #[rstest]
+    fn test_selector_api_with_key_prefix(queries: Vec<Query>, js_lang: Language) {
+        let code = r#"
+            const { t } = useTranslation("translation", { keyPrefix: "user.settings" });
+            const message = t($ => $.title);
+        "#;
+
+        let calls =
+            analyze_trans_fn_calls(code, &js_lang, ProgrammingLanguage::JavaScript, &queries, ".")
+                .unwrap();
+
+        assert_that!(
+            calls,
+            elements_are![all![
+                field!(TransFnCall.key, eq("user.settings.title")),
+                field!(TransFnCall.arg_key, eq("title"))
+            ]]
+        );
+    }
+
+    #[rstest]
+    fn test_selector_api_with_interpolation(queries: Vec<Query>, js_lang: Language) {
+        let code = r#"
+            const { t } = useTranslation();
+            const message = t($ => $.greeting, { name: "World" });
+        "#;
+
+        let calls =
+            analyze_trans_fn_calls(code, &js_lang, ProgrammingLanguage::JavaScript, &queries, ".")
+                .unwrap();
+
+        assert_that!(calls, elements_are![field!(TransFnCall.key, eq("greeting"))]);
+    }
+
+    #[rstest]
+    fn test_selector_api_subscript_expression(queries: Vec<Query>, js_lang: Language) {
+        let code = r"
+            const { t } = useTranslation();
+            const message = t($ => $[0][1][2]);
+        ";
+
+        let calls =
+            analyze_trans_fn_calls(code, &js_lang, ProgrammingLanguage::JavaScript, &queries, ".")
+                .unwrap();
+
+        assert_that!(calls, elements_are![field!(TransFnCall.key, eq("0.1.2"))]);
+    }
+
+    #[rstest]
+    fn test_selector_api_mixed_with_string(queries: Vec<Query>, js_lang: Language) {
+        let code = r#"
+            const { t } = useTranslation();
+            const msg1 = t("string.key");
+            const msg2 = t($ => $.selector.key);
+        "#;
+
+        let calls =
+            analyze_trans_fn_calls(code, &js_lang, ProgrammingLanguage::JavaScript, &queries, ".")
+                .unwrap();
+
+        assert_that!(
+            calls,
+            elements_are![
+                field!(TransFnCall.key, eq("string.key")),
+                field!(TransFnCall.key, eq("selector.key"))
+            ]
+        );
+    }
+
+    #[rstest]
+    fn test_selector_api_global_t(queries: Vec<Query>, js_lang: Language) {
+        let code = r"
+            const message = i18next.t($ => $.global.key);
+        ";
+
+        let calls =
+            analyze_trans_fn_calls(code, &js_lang, ProgrammingLanguage::JavaScript, &queries, ".")
+                .unwrap();
+
+        assert_that!(calls, elements_are![field!(TransFnCall.key, eq("global.key"))]);
+    }
+
+    #[rstest]
+    fn test_selector_api_get_fixed_t(queries: Vec<Query>, js_lang: Language) {
+        let code = r#"
+            const t = i18n.getFixedT(null, "common", "buttons");
+            const message = t($ => $.save);
+        "#;
+
+        let calls =
+            analyze_trans_fn_calls(code, &js_lang, ProgrammingLanguage::JavaScript, &queries, ".")
+                .unwrap();
+
+        assert_that!(
+            calls,
+            elements_are![all![
+                field!(TransFnCall.key, eq("buttons.save")),
+                field!(TransFnCall.arg_key, eq("save"))
+            ]]
+        );
+    }
+
+    #[rstest]
+    fn test_selector_api_trans_component(tsx_queries: Vec<Query>, tsx_lang: Language) {
+        let code = r"
+            const { t } = useTranslation();
+            return <Trans i18nKey={($) => $.foo.bar} />;
+        ";
+
+        let calls =
+            analyze_trans_fn_calls(code, &tsx_lang, ProgrammingLanguage::Tsx, &tsx_queries, ".")
+                .unwrap();
+
+        assert_that!(calls, elements_are![field!(TransFnCall.key, eq("foo.bar"))]);
     }
 }

--- a/src/syntax/analyzer/extractor.rs
+++ b/src/syntax/analyzer/extractor.rs
@@ -607,9 +607,11 @@ fn parse_call_trans_fn_captures<'a>(
         let selector_key =
             extract_selector_key(selector_node, source_bytes, key_separator).unwrap_or_default();
 
-        // Extend the range past trailing accessor operators (`.` or `[`) that tree-sitter
-        // excludes from the arrow function node for incomplete expressions like `$ => $.common.`
-        let extended_range = extend_range_past_accessors(selector_node, source_bytes);
+        // Use the body node (e.g., `$.common.hello`) for the range instead of the full
+        // arrow function, so that go-to-definition and rename target only the key expression.
+        // Extend past trailing accessor operators for incomplete expressions like `$.common.`
+        let body_node = selector_node.child_by_field_name("body").unwrap_or(selector_node);
+        let extended_range = extend_range_past_accessors(body_node, source_bytes);
 
         return Ok(CallTransFnDetail {
             trans_fn_name: trans_fn_name.unwrap_or_else(|| "t".to_string()),

--- a/src/syntax/analyzer/extractor.rs
+++ b/src/syntax/analyzer/extractor.rs
@@ -2103,4 +2103,81 @@ function Component() {
 
         assert_that!(calls, elements_are![field!(TransFnCall.key, eq("foo.bar"))]);
     }
+
+    #[rstest]
+    fn test_selector_api_subscript_string_index(queries: Vec<Query>, js_lang: Language) {
+        // $["key"] subscript with string index
+        let code = r#"
+            const { t } = useTranslation();
+            const msg = t($ => $["hello"]);
+        "#;
+
+        let calls =
+            analyze_trans_fn_calls(code, &js_lang, ProgrammingLanguage::JavaScript, &queries, ".")
+                .unwrap();
+
+        assert_that!(calls, elements_are![field!(TransFnCall.key, eq("hello"))]);
+    }
+
+    #[rstest]
+    fn test_selector_api_subscript_unknown_index(queries: Vec<Query>, js_lang: Language) {
+        // $[variable] — unsupported subscript type, should produce a call with partial key
+        let code = r"
+            const { t } = useTranslation();
+            const msg = t($ => $[someVar]);
+        ";
+
+        let calls =
+            analyze_trans_fn_calls(code, &js_lang, ProgrammingLanguage::JavaScript, &queries, ".")
+                .unwrap();
+
+        // extract_selector_key fails → unwrap_or_default → empty key
+        assert_that!(calls, elements_are![field!(TransFnCall.key, eq(""))]);
+    }
+
+    #[rstest]
+    fn test_selector_api_tsx_parens(tsx_queries: Vec<Query>, tsx_lang: Language) {
+        // TSX with ($) — exercises required_parameter path in extract_arrow_param_name
+        let code = r"
+            const { t } = useTranslation();
+            const msg = t(($) => $.nested.key);
+        ";
+
+        let calls =
+            analyze_trans_fn_calls(code, &tsx_lang, ProgrammingLanguage::Tsx, &tsx_queries, ".")
+                .unwrap();
+
+        assert_that!(calls, elements_are![field!(TransFnCall.key, eq("nested.key"))]);
+    }
+
+    #[rstest]
+    fn test_selector_api_custom_key_separator(queries: Vec<Query>, js_lang: Language) {
+        // Non-dot key separator: member expression `.` is joined with `_`
+        let code = r"
+            const { t } = useTranslation();
+            const msg = t($ => $.common.hello);
+        ";
+
+        let calls =
+            analyze_trans_fn_calls(code, &js_lang, ProgrammingLanguage::JavaScript, &queries, "_")
+                .unwrap();
+
+        assert_that!(calls, elements_are![field!(TransFnCall.key, eq("common_hello"))]);
+    }
+
+    #[rstest]
+    fn test_selector_api_param_only(queries: Vec<Query>, js_lang: Language) {
+        // `$ => $` — just the parameter, no property access
+        let code = r"
+            const { t } = useTranslation();
+            const msg = t($ => $);
+        ";
+
+        let calls =
+            analyze_trans_fn_calls(code, &js_lang, ProgrammingLanguage::JavaScript, &queries, ".")
+                .unwrap();
+
+        // Empty key (root)
+        assert_that!(calls, elements_are![field!(TransFnCall.key, eq(""))]);
+    }
 }

--- a/src/syntax/analyzer/extractor.rs
+++ b/src/syntax/analyzer/extractor.rs
@@ -122,40 +122,15 @@ fn get_node_range(node: Node<'_>) -> Range {
     )
 }
 
-/// Extracts translation function calls from a Tree-sitter syntax tree.
+/// Collects, sorts, and deduplicates captures from all queries.
 ///
-/// # Errors
-/// Returns `AnalyzerError` if:
-/// - Language setup fails
-/// - Source code parsing fails
-/// - Query execution encounters issues
-pub fn analyze_trans_fn_calls(
-    source: &str,
-    language: &Language,
-    programming_language: ProgrammingLanguage,
+/// Returns captures sorted by source position with `GetTransFn` before `CallTransFn` at equal positions.
+fn collect_and_sort_captures<'a>(
     queries: &[Query],
-    key_separator: &str,
-) -> Result<Vec<TransFnCall>, AnalyzerError> {
-    let config = FrameworkConfig::for_language(programming_language);
-    let mut parser = Parser::new();
-    parser.set_language(language).map_err(AnalyzerError::LanguageSetup)?;
-    let tree = parser.parse(source, None).ok_or(AnalyzerError::ParseFailed)?;
-
-    let source_bytes = source.as_bytes();
-
-    let mut calls = Vec::new();
-    let root_node = tree.root_node();
-
-    let mut scopes = Scopes::new();
-
-    // Add default scope for bare `t` function
-    scopes.push_scope("t".to_string(), ScopeInfo::new(root_node, GetTransFnDetail::new("t")));
-
-    // Collect matches from all queries and process them in source position order.
-    // This ensures that translation function definitions (e.g., useTranslation) are
-    // processed before their call sites, even when defined in separate query files
-    // (e.g., i18next.scm and react-i18next.scm).
-    let mut all_captures: Vec<(usize, CaptureName, Node<'_>, usize)> = Vec::new();
+    root_node: Node<'a>,
+    source_bytes: &'a [u8],
+) -> Vec<(usize, CaptureName, Node<'a>, usize)> {
+    let mut all_captures: Vec<(usize, CaptureName, Node<'a>, usize)> = Vec::new();
 
     for (query_idx, query) in queries.iter().enumerate() {
         let cap_names = query.capture_names();
@@ -198,6 +173,40 @@ pub fn analyze_trans_fn_calls(
     // Multiple query patterns (e.g., string-based and selector-based t() calls) can match
     // the same node, producing duplicate CallTransFn entries.
     all_captures.dedup_by(|a, b| a.1 == b.1 && a.3 == b.3 && a.0 == b.0);
+
+    all_captures
+}
+
+/// Extracts translation function calls from a Tree-sitter syntax tree.
+///
+/// # Errors
+/// Returns `AnalyzerError` if:
+/// - Language setup fails
+/// - Source code parsing fails
+/// - Query execution encounters issues
+pub fn analyze_trans_fn_calls(
+    source: &str,
+    language: &Language,
+    programming_language: ProgrammingLanguage,
+    queries: &[Query],
+    key_separator: &str,
+) -> Result<Vec<TransFnCall>, AnalyzerError> {
+    let config = FrameworkConfig::for_language(programming_language);
+    let mut parser = Parser::new();
+    parser.set_language(language).map_err(AnalyzerError::LanguageSetup)?;
+    let tree = parser.parse(source, None).ok_or(AnalyzerError::ParseFailed)?;
+
+    let source_bytes = source.as_bytes();
+
+    let mut calls = Vec::new();
+    let root_node = tree.root_node();
+
+    let mut scopes = Scopes::new();
+
+    // Add default scope for bare `t` function
+    scopes.push_scope("t".to_string(), ScopeInfo::new(root_node, GetTransFnDetail::new("t")));
+
+    let all_captures = collect_and_sort_captures(queries, root_node, source_bytes);
 
     for (query_idx, capture_name, node, _) in all_captures {
         let Some(query) = queries.get(query_idx) else {
@@ -574,9 +583,10 @@ fn parse_call_trans_fn_captures<'a>(
     }
 
     // Handle Selector API: t($ => $.a.b.c)
+    // Use unwrap_or_default for incomplete selectors (e.g., `$ => $.common.`) to support completion
     if let Some(selector_node) = selector_fn_node {
-        let selector_key = extract_selector_key(selector_node, source_bytes, key_separator)
-            .ok_or(AnalyzerError::ParseFailed)?;
+        let selector_key =
+            extract_selector_key(selector_node, source_bytes, key_separator).unwrap_or_default();
 
         return Ok(CallTransFnDetail {
             trans_fn_name: trans_fn_name.unwrap_or_else(|| "t".to_string()),

--- a/src/syntax/analyzer/types.rs
+++ b/src/syntax/analyzer/types.rs
@@ -25,6 +25,7 @@ pub enum CaptureName {
     ExplicitNamespace,
     KeyPrefix,
     GetTransFnArgs,
+    SelectorFn,
 }
 
 impl CaptureName {
@@ -43,6 +44,7 @@ impl CaptureName {
             Self::ExplicitNamespace => "i18n.explicit_namespace",
             Self::KeyPrefix => "i18n.trans_key_prefix",
             Self::GetTransFnArgs => "i18n.get_trans_fn_args",
+            Self::SelectorFn => "i18n.selector_fn",
         }
     }
 }
@@ -67,6 +69,7 @@ impl FromStr for CaptureName {
             "i18n.explicit_namespace" => Ok(Self::ExplicitNamespace),
             "i18n.trans_key_prefix" => Ok(Self::KeyPrefix),
             "i18n.get_trans_fn_args" => Ok(Self::GetTransFnArgs),
+            "i18n.selector_fn" => Ok(Self::SelectorFn),
             _ => Err(ParseCaptureNameError),
         }
     }

--- a/src/syntax/analyzer/types.rs
+++ b/src/syntax/analyzer/types.rs
@@ -94,6 +94,9 @@ pub struct CallTransFnDetail<'a> {
     pub key_node: Node<'a>,
     pub arg_key_node: Node<'a>,
     pub explicit_namespace: Option<String>,
+    /// Overrides the range computed from `arg_key_node` when set.
+    /// Used by Selector API to extend the range past trailing accessor operators.
+    pub arg_key_range: Option<Range>,
 }
 
 #[derive(Debug, Clone, Default)]


### PR DESCRIPTION
## Summary

Add support for i18next v25.4.0+ Selector API (`t(($) => $.key)`) — an arrow function callback syntax for type-safe translation key specification.

- Extend tree-sitter queries, key extraction, and all IDE features (hover, diagnostics, go-to-definition, completion) to recognize selector patterns
- Add `frameworks.i18next.preferSelector` setting to control whether `t(|)` completions insert selector format or string format
- Introduce `frameworks` namespace in `.js-i18n.json` for per-framework configuration

## How to test

1. Open a playground file (e.g., `playground/i18next/selectorApi.ts`)
2. Verify hover shows translation values on `($) => $.common.hello`
3. Verify diagnostics detect missing keys in selector expressions
4. Verify go-to-definition jumps to the key in the translation JSON
5. Verify completion works inside `$ => $.common.|` (after trailing dot)
6. Set `"frameworks": { "i18next": { "preferSelector": true } }` in `.js-i18n.json`
7. Verify `t(|)` completions now insert `($) => $.key` format

## Related issues

Closes #10

## Checklist

- [x] Related issues are linked above
- [x] No new dependencies without justification
- [x] Breaking changes to config are documented
- [x] Documentation updated (`README.md`, `docs/`)
- [x] Tests added/updated for new behavior