### PR TITLE
feat: add vue-i18n support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,3 +215,7 @@ Temporary Items
 nohup.out
 
 .repro_minimal
+
+# Playground (npm)
+playground/*/node_modules/
+playground/*/dist/

--- a/docs/supported-syntax.md
+++ b/docs/supported-syntax.md
@@ -6,6 +6,7 @@
 - [react-i18next](https://react.i18next.com/)
 - [next-intl](https://next-intl-docs.vercel.app/)
 - [svelte-i18n](https://github.com/kaisermann/svelte-i18n)
+- [vue-i18n](https://vue-i18n.intlify.dev/)
 
 ## Translation Function Calls
 
@@ -158,6 +159,82 @@ const messages = defineMessages({
 })
 ```
 
+## vue-i18n
+
+Vue.js i18n library support. Works in `.vue` files (both `<script>` and `<template>`) and plain `.js`/`.ts` files. Targets v9+ (Vue 3 Composition API) with v8 (Legacy API) compatibility.
+
+Also covers `petite-vue-i18n` and `@nuxtjs/i18n` (same API).
+
+### Composition API
+
+```vue
+<script setup>
+import { useI18n } from 'vue-i18n'
+
+// Destructuring
+const { t, te, tm } = useI18n()
+t('key')
+te('key')  // Key existence check
+tm('key')  // Raw message object
+
+// Object access pattern
+const i18n = useI18n()
+i18n.t('key')
+</script>
+```
+
+### Options API
+
+```vue
+<script>
+export default {
+  computed: {
+    title() { return this.$t('greeting') },
+    exists() { return this.$te('optional') }
+  }
+}
+</script>
+```
+
+### Template Patterns
+
+```vue
+<template>
+  <!-- Mustache interpolation -->
+  {{ $t('message.hello') }}
+
+  <!-- Attribute binding -->
+  <input :placeholder="$t('form.placeholder')" />
+
+  <!-- Directives -->
+  <span v-if="$te('optional')">{{ $t('optional') }}</span>
+  <span v-show="$te('visible')">{{ $t('visible') }}</span>
+
+  <!-- Translation component (v9+) -->
+  <i18n-t keypath="terms" tag="p">
+    <template #link><a href="/tos">{{ $t('tos') }}</a></template>
+  </i18n-t>
+
+  <!-- Translation component (v8) -->
+  <i18n path="terms" tag="p">
+    <a slot="link" href="/tos">{{ $t('tos') }}</a>
+  </i18n>
+
+  <!-- v-t directive -->
+  <p v-t="'message.hello'"></p>
+  <p v-t="{ path: 'message.hello', args: { name: userName } }"></p>
+</template>
+```
+
+### Global Functions
+
+| Function | Purpose |
+|----------|---------|
+| `$t(key)` | Translate |
+| `$tc(key, count)` | Pluralize (deprecated v10) |
+| `$te(key)` | Key existence check |
+| `$tm(key)` | Raw message object |
+
 ## File Types
 
 | Extension | tree-sitter Parser | Notes |
@@ -167,3 +244,4 @@ const messages = defineMessages({
 | `.ts` | TypeScript | |
 | `.tsx` | TSX | |
 | `.svelte` | TypeScript (extracted) | `<script>` blocks and template expressions are extracted and parsed as TypeScript |
+| `.vue` | TypeScript (extracted) | `<script>` blocks and template expressions are extracted and parsed as TypeScript |

--- a/playground/vue-i18n/.js-i18n.json
+++ b/playground/vue-i18n/.js-i18n.json
@@ -1,0 +1,6 @@
+{
+  "includePatterns": ["**/*.{js,ts,vue}"],
+  "translationFiles": {
+    "includePatterns": ["locales/**/*.json"]
+  }
+}

--- a/playground/vue-i18n/index.html
+++ b/playground/vue-i18n/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>vue-i18n Playground</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/playground/vue-i18n/locales/en.json
+++ b/playground/vue-i18n/locales/en.json
@@ -1,0 +1,31 @@
+{
+  "app": {
+    "title": "Vue i18n Examples",
+    "language": "Select Language"
+  },
+  "page": {
+    "title": "Page Title",
+    "description": "Page Description"
+  },
+  "message": {
+    "hello": "Hello",
+    "welcome": "Welcome, {name}!",
+    "goodbye": "Goodbye"
+  },
+  "form": {
+    "placeholder": "Enter text...",
+    "submit": "Submit"
+  },
+  "terms": "Please read the {link}.",
+  "tos": "Terms of Service",
+  "optional": "Optional content",
+  "visible": "Visible content",
+  "common": {
+    "ok": "OK",
+    "cancel": "Cancel"
+  },
+  "plural": {
+    "car": "no cars | one car | {count} cars",
+    "apple": "no apples | one apple | {count} apples"
+  }
+}

--- a/playground/vue-i18n/locales/ja.json
+++ b/playground/vue-i18n/locales/ja.json
@@ -1,0 +1,31 @@
+{
+  "app": {
+    "title": "Vue i18n サンプル",
+    "language": "言語選択"
+  },
+  "page": {
+    "title": "ページタイトル",
+    "description": "ページの説明"
+  },
+  "message": {
+    "hello": "こんにちは",
+    "welcome": "ようこそ、{name}さん！",
+    "goodbye": "さようなら"
+  },
+  "form": {
+    "placeholder": "テキストを入力...",
+    "submit": "送信"
+  },
+  "terms": "{link}をお読みください。",
+  "tos": "利用規約",
+  "optional": "オプションコンテンツ",
+  "visible": "表示コンテンツ",
+  "common": {
+    "ok": "OK",
+    "cancel": "キャンセル"
+  },
+  "plural": {
+    "car": "車がありません | 車が1台 | 車が{count}台",
+    "apple": "りんごがありません | りんごが1個 | りんごが{count}個"
+  }
+}

--- a/playground/vue-i18n/package-lock.json
+++ b/playground/vue-i18n/package-lock.json
@@ -1,0 +1,1435 @@
+{
+  "name": "vue-i18n-playground",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vue-i18n-playground",
+      "version": "0.0.0",
+      "dependencies": {
+        "vue": "^3.5.0",
+        "vue-i18n": "^10.0.0"
+      },
+      "devDependencies": {
+        "@vitejs/plugin-vue": "^5.0.0",
+        "vite": "^6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@intlify/core-base": {
+      "version": "10.0.8",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-10.0.8.tgz",
+      "integrity": "sha512-FoHslNWSoHjdUBLy35bpm9PV/0LVI/DSv9L6Km6J2ad8r/mm0VaGg06C40FqlE8u2ADcGUM60lyoU7Myo4WNZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/message-compiler": "10.0.8",
+        "@intlify/shared": "10.0.8"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/message-compiler": {
+      "version": "10.0.8",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-10.0.8.tgz",
+      "integrity": "sha512-DV+sYXIkHVd5yVb2mL7br/NEUwzUoLBsMkV3H0InefWgmYa34NLZUvMCGi5oWX+Hqr2Y2qUxnVrnOWF4aBlgWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/shared": "10.0.8",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/shared": {
+      "version": "10.0.8",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-10.0.8.tgz",
+      "integrity": "sha512-BcmHpb5bQyeVNrptC3UhzpBZB/YHHDoEREOUERrmF2BRxsyOEuRrq+Z96C/D4+2KJb8kuHiouzAei7BXlG0YYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.0.tgz",
+      "integrity": "sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.0.tgz",
+      "integrity": "sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.0.tgz",
+      "integrity": "sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.0.tgz",
+      "integrity": "sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.0.tgz",
+      "integrity": "sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.0.tgz",
+      "integrity": "sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.0.tgz",
+      "integrity": "sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.0.tgz",
+      "integrity": "sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.0.tgz",
+      "integrity": "sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.0.tgz",
+      "integrity": "sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.0.tgz",
+      "integrity": "sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.0.tgz",
+      "integrity": "sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.0.tgz",
+      "integrity": "sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.0.tgz",
+      "integrity": "sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.0.tgz",
+      "integrity": "sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.0.tgz",
+      "integrity": "sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.0.tgz",
+      "integrity": "sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.0.tgz",
+      "integrity": "sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.0.tgz",
+      "integrity": "sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.0.tgz",
+      "integrity": "sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.0.tgz",
+      "integrity": "sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.0.tgz",
+      "integrity": "sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.0.tgz",
+      "integrity": "sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.0.tgz",
+      "integrity": "sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.0.tgz",
+      "integrity": "sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.31",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.31.tgz",
+      "integrity": "sha512-k/ueL14aNIEy5Onf0OVzR8kiqF/WThgLdFhxwa4e/KF/0qe38IwIdofoSWBTvvxQOesaz6riAFAUaYjoF9fLLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.2",
+        "@vue/shared": "3.5.31",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.31",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.31.tgz",
+      "integrity": "sha512-BMY/ozS/xxjYqRFL+tKdRpATJYDTTgWSo0+AJvJNg4ig+Hgb0dOsHPXvloHQ5hmlivUqw1Yt2pPIqp4e0v1GUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.31",
+        "@vue/shared": "3.5.31"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.31",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.31.tgz",
+      "integrity": "sha512-M8wpPgR9UJ8MiRGjppvx9uWJfLV7A/T+/rL8s/y3QG3u0c2/YZgff3d6SuimKRIhcYnWg5fTfDMlz2E6seUW8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.2",
+        "@vue/compiler-core": "3.5.31",
+        "@vue/compiler-dom": "3.5.31",
+        "@vue/compiler-ssr": "3.5.31",
+        "@vue/shared": "3.5.31",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.8",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.31",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.31.tgz",
+      "integrity": "sha512-h0xIMxrt/LHOvJKMri+vdYT92BrK3HFLtDqq9Pr/lVVfE4IyKZKvWf0vJFW10Yr6nX02OR4MkJwI0c1HDa1hog==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.31",
+        "@vue/shared": "3.5.31"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.31",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.31.tgz",
+      "integrity": "sha512-DtKXxk9E/KuVvt8VxWu+6Luc9I9ETNcqR1T1oW1gf02nXaZ1kuAx58oVu7uX9XxJR0iJCro6fqBLw9oSBELo5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.31"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.31",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.31.tgz",
+      "integrity": "sha512-AZPmIHXEAyhpkmN7aWlqjSfYynmkWlluDNPHMCZKFHH+lLtxP/30UJmoVhXmbDoP1Ng0jG0fyY2zCj1PnSSA6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.31",
+        "@vue/shared": "3.5.31"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.31",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.31.tgz",
+      "integrity": "sha512-xQJsNRmGPeDCJq/u813tyonNgWBFjzfVkBwDREdEWndBnGdHLHgkwNBQxLtg4zDrzKTEcnikUy1UUNecb3lJ6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.31",
+        "@vue/runtime-core": "3.5.31",
+        "@vue/shared": "3.5.31",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.31",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.31.tgz",
+      "integrity": "sha512-GJuwRvMcdZX/CriUnyIIOGkx3rMV3H6sOu0JhdKbduaeCji6zb60iOGMY7tFoN24NfsUYoFBhshZtGxGpxO4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.31",
+        "@vue/shared": "3.5.31"
+      },
+      "peerDependencies": {
+        "vue": "3.5.31"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.31",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.31.tgz",
+      "integrity": "sha512-nBxuiuS9Lj5bPkPbWogPUnjxxWpkRniX7e5UBQDWl6Fsf4roq9wwV+cR7ezQ4zXswNvPIlsdj1slcLB7XCsRAw==",
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.0.tgz",
+      "integrity": "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.0",
+        "@rollup/rollup-android-arm64": "4.60.0",
+        "@rollup/rollup-darwin-arm64": "4.60.0",
+        "@rollup/rollup-darwin-x64": "4.60.0",
+        "@rollup/rollup-freebsd-arm64": "4.60.0",
+        "@rollup/rollup-freebsd-x64": "4.60.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.0",
+        "@rollup/rollup-linux-arm64-musl": "4.60.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.0",
+        "@rollup/rollup-linux-loong64-musl": "4.60.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.0",
+        "@rollup/rollup-linux-x64-gnu": "4.60.0",
+        "@rollup/rollup-linux-x64-musl": "4.60.0",
+        "@rollup/rollup-openbsd-x64": "4.60.0",
+        "@rollup/rollup-openharmony-arm64": "4.60.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.0",
+        "@rollup/rollup-win32-x64-gnu": "4.60.0",
+        "@rollup/rollup-win32-x64-msvc": "4.60.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
+      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.31",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.31.tgz",
+      "integrity": "sha512-iV/sU9SzOlmA/0tygSmjkEN6Jbs3nPoIPFhCMLD2STrjgOU8DX7ZtzMhg4ahVwf5Rp9KoFzcXeB1ZrVbLBp5/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.31",
+        "@vue/compiler-sfc": "3.5.31",
+        "@vue/runtime-dom": "3.5.31",
+        "@vue/server-renderer": "3.5.31",
+        "@vue/shared": "3.5.31"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-i18n": {
+      "version": "10.0.8",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-10.0.8.tgz",
+      "integrity": "sha512-mIjy4utxMz9lMMo6G9vYePv7gUFt4ztOMhY9/4czDJxZ26xPeJ49MAGa9wBAE3XuXbYCrtVPmPxNjej7JJJkZQ==",
+      "deprecated": "v9 and v10 no longer supported. please migrate to v11. about maintenance status, see https://vue-i18n.intlify.dev/guide/maintenance.html",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/core-base": "10.0.8",
+        "@intlify/shared": "10.0.8",
+        "@vue/devtools-api": "^6.5.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
+      }
+    }
+  }
+}

--- a/playground/vue-i18n/package.json
+++ b/playground/vue-i18n/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "vue-i18n-playground",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "vue": "^3.5.0",
+    "vue-i18n": "^10.0.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.0",
+    "vite": "^6.0.0"
+  }
+}

--- a/playground/vue-i18n/src/App.vue
+++ b/playground/vue-i18n/src/App.vue
@@ -1,0 +1,84 @@
+<script setup>
+import { useI18n } from "vue-i18n";
+import CompositionApi from "./CompositionApi.vue";
+import OptionsApi from "./OptionsApi.vue";
+import TemplatePatterns from "./TemplatePatterns.vue";
+import ObjectAccess from "./ObjectAccess.vue";
+
+const { t, locale, availableLocales } = useI18n();
+</script>
+
+<template>
+  <main>
+    <h1>{{ $t("app.title") }}</h1>
+
+    <div class="locale-switcher">
+      <label>
+        {{ $t("app.language") }}:
+        <select v-model="locale">
+          <option v-for="loc in availableLocales" :key="loc" :value="loc">
+            {{ loc }}
+          </option>
+        </select>
+      </label>
+    </div>
+
+    <section>
+      <h2>Composition API</h2>
+      <CompositionApi />
+    </section>
+
+    <section>
+      <h2>Options API</h2>
+      <OptionsApi />
+    </section>
+
+    <section>
+      <h2>Template Patterns</h2>
+      <TemplatePatterns />
+    </section>
+
+    <section>
+      <h2>Object Access</h2>
+      <ObjectAccess />
+    </section>
+  </main>
+</template>
+
+<style>
+main {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+h1 {
+  border-bottom: 2px solid #333;
+  padding-bottom: 0.5rem;
+}
+
+section {
+  margin: 2rem 0;
+  padding: 1rem;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+}
+
+h2 {
+  margin-top: 0;
+  color: #555;
+}
+
+.locale-switcher {
+  margin: 1rem 0;
+  padding: 0.5rem;
+  background: #f5f5f5;
+  border-radius: 4px;
+}
+
+select {
+  padding: 0.25rem 0.5rem;
+  font-size: 1rem;
+}
+</style>

--- a/playground/vue-i18n/src/CompositionApi.vue
+++ b/playground/vue-i18n/src/CompositionApi.vue
@@ -1,27 +1,32 @@
 <script setup lang="ts">
-import { useI18n } from 'vue-i18n'
+import { useI18n } from "vue-i18n";
 
-// Destructured form
-const { t, te, tm } = useI18n()
-
-const greeting = t('message.hello')
-const exists = te('optional')
-const raw = tm('message')
+const { t, te, tm, rt } = useI18n();
 </script>
 
 <template>
   <div>
-    <h2>{{ $t('page.title') }}</h2>
-    <p>{{ $t('page.description') }}</p>
+    <h2>{{ $t("page.title") }}</h2>
+    <p>{{ $t("page.description") }}</p>
+    <p>{{ t("message.welcome", { name: "World" }) }}</p>
 
     <!-- Attribute binding -->
     <input :placeholder="$t('form.placeholder')" />
 
-    <!-- Conditional rendering -->
-    <span v-if="$te('optional')">{{ $t('optional') }}</span>
-    <span v-show="$te('visible')">{{ $t('visible') }}</span>
+    <!-- Conditional rendering with te -->
+    <span v-if="te('optional')">{{ t("optional") }}</span>
+    <span v-show="$te('visible')">{{ $t("visible") }}</span>
+
+    <!-- tm + rt: iterate raw message object -->
+    <ul>
+      <li v-for="(msg, key) in tm('common')" :key="key">
+        {{ key }}: {{ rt(msg) }}
+      </li>
+    </ul>
 
     <!-- Event handler -->
-    <button @click="alert($t('message.hello'))">{{ $t('form.submit') }}</button>
+    <button @click="alert($t('message.hello'))">
+      {{ $t("form.submit") }}
+    </button>
   </div>
 </template>

--- a/playground/vue-i18n/src/CompositionApi.vue
+++ b/playground/vue-i18n/src/CompositionApi.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
+// Destructured form
+const { t, te, tm } = useI18n()
+
+const greeting = t('message.hello')
+const exists = te('optional')
+const raw = tm('message')
+</script>
+
+<template>
+  <div>
+    <h2>{{ $t('page.title') }}</h2>
+    <p>{{ $t('page.description') }}</p>
+
+    <!-- Attribute binding -->
+    <input :placeholder="$t('form.placeholder')" />
+
+    <!-- Conditional rendering -->
+    <span v-if="$te('optional')">{{ $t('optional') }}</span>
+    <span v-show="$te('visible')">{{ $t('visible') }}</span>
+
+    <!-- Event handler -->
+    <button @click="alert($t('message.hello'))">{{ $t('form.submit') }}</button>
+  </div>
+</template>

--- a/playground/vue-i18n/src/ObjectAccess.vue
+++ b/playground/vue-i18n/src/ObjectAccess.vue
@@ -1,0 +1,13 @@
+<script setup>
+import { useI18n } from 'vue-i18n'
+
+// Object access pattern
+const i18n = useI18n()
+const title = i18n.t('page.title')
+</script>
+
+<template>
+  <div>
+    <h2>{{ $t('page.title') }}</h2>
+  </div>
+</template>

--- a/playground/vue-i18n/src/OptionsApi.vue
+++ b/playground/vue-i18n/src/OptionsApi.vue
@@ -1,0 +1,23 @@
+<script>
+export default {
+  name: 'OptionsApi',
+  computed: {
+    title() {
+      return this.$t('page.title')
+    },
+    description() {
+      return this.$t('page.description')
+    },
+    hasOptional() {
+      return this.$te('optional')
+    }
+  }
+}
+</script>
+
+<template>
+  <div>
+    <h2>{{ $t('page.title') }}</h2>
+    <p>{{ $t('message.welcome', { name: 'World' }) }}</p>
+  </div>
+</template>

--- a/playground/vue-i18n/src/TemplatePatterns.vue
+++ b/playground/vue-i18n/src/TemplatePatterns.vue
@@ -1,0 +1,33 @@
+<script setup>
+import { useI18n } from 'vue-i18n'
+const { t } = useI18n()
+</script>
+
+<template>
+  <div>
+    <!-- i18n-t component (v9+) -->
+    <i18n-t keypath="terms" tag="p">
+      <template #link>
+        <a href="/tos">{{ $t('tos') }}</a>
+      </template>
+    </i18n-t>
+
+    <!-- I18nT PascalCase -->
+    <I18nT keypath="terms" tag="p">
+      <template #link>
+        <a href="/tos">{{ $t('tos') }}</a>
+      </template>
+    </I18nT>
+
+    <!-- i18n component (v8) -->
+    <i18n path="terms" tag="p">
+      <a slot="link" href="/tos">{{ $t('tos') }}</a>
+    </i18n>
+
+    <!-- v-t directive: string syntax -->
+    <p v-t="'message.hello'"></p>
+
+    <!-- v-t directive: object syntax -->
+    <p v-t="{ path: 'message.goodbye', args: { name: 'World' } }"></p>
+  </div>
+</template>

--- a/playground/vue-i18n/src/i18n.js
+++ b/playground/vue-i18n/src/i18n.js
@@ -1,0 +1,12 @@
+import { createI18n } from "vue-i18n";
+import en from "../locales/en.json";
+import ja from "../locales/ja.json";
+
+const i18n = createI18n({
+  legacy: false,
+  locale: navigator.language.startsWith("ja") ? "ja" : "en",
+  fallbackLocale: "en",
+  messages: { en, ja },
+});
+
+export default i18n;

--- a/playground/vue-i18n/src/main.js
+++ b/playground/vue-i18n/src/main.js
@@ -1,0 +1,7 @@
+import { createApp } from "vue";
+import App from "./App.vue";
+import i18n from "./i18n.js";
+
+const app = createApp(App);
+app.use(i18n);
+app.mount("#app");

--- a/playground/vue-i18n/vite.config.js
+++ b/playground/vue-i18n/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import vue from "@vitejs/plugin-vue";
+
+export default defineConfig({
+  plugins: [vue()],
+});

--- a/queries/vue-i18n.scm
+++ b/queries/vue-i18n.scm
@@ -1,0 +1,45 @@
+;; useI18n() destructuring: const { t, te, tm } = useI18n()
+;; Registers destructured variables as translation functions (GetTransFn).
+(variable_declarator
+  name: (object_pattern
+    [
+      (pair_pattern
+        key: (property_identifier) @_use_i18n_key (#match? @_use_i18n_key "^(t|te|tm)$")
+        value: (identifier) @i18n.get_trans_fn_name
+      )
+      (shorthand_property_identifier_pattern) @i18n.get_trans_fn_name
+        (#match? @i18n.get_trans_fn_name "^(t|te|tm)$")
+    ]
+  )
+  value:
+    (call_expression
+      function: (identifier) @_use_i18n (#eq? @_use_i18n "useI18n")
+    )
+) @i18n.get_trans_fn
+
+;; useI18n() assigned to variable: const i18n = useI18n(); i18n.t('key')
+;; The variable itself is registered so i18n.t() is recognized via member expression.
+(variable_declarator
+  name: (identifier) @i18n.get_trans_fn_name
+  value:
+    (call_expression
+      function: (identifier) @_use_i18n_obj (#eq? @_use_i18n_obj "useI18n")
+    )
+) @i18n.get_trans_fn
+
+;; this.$t('key'), this.$tc('key'), this.$te('key'), this.$tm('key')
+;; Member expression on `this` with vue-i18n global functions.
+(call_expression
+  function:
+    (member_expression
+      object: (this) @_this
+      property: (property_identifier) @i18n.call_trans_fn_name
+        (#match? @i18n.call_trans_fn_name "^\\$(t|tc|te|tm)$")
+    )
+  arguments: (arguments
+    (string
+      (string_fragment)? @i18n.trans_key
+    )? @i18n.trans_key_arg
+    (_)*
+  ) @i18n.trans_args
+) @i18n.call_trans_fn

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -261,7 +261,7 @@ impl Default for I18nSettings {
     fn default() -> Self {
         Self {
             translation_files: TranslationFilesConfig::default(),
-            include_patterns: vec!["**/*.{js,jsx,ts,tsx,svelte}".to_string()],
+            include_patterns: vec!["**/*.{js,jsx,ts,tsx,svelte,vue}".to_string()],
             exclude_patterns: vec!["node_modules/**".to_string()],
             key_separator: ".".to_string(),
             namespace_separator: None,
@@ -428,7 +428,10 @@ mod tests {
         let settings: I18nSettings = serde_json::from_str(json).unwrap();
 
         assert_that!(settings.key_separator, eq("."));
-        assert_that!(settings.include_patterns, elements_are![eq("**/*.{js,jsx,ts,tsx,svelte}")]);
+        assert_that!(
+            settings.include_patterns,
+            elements_are![eq("**/*.{js,jsx,ts,tsx,svelte,vue}")]
+        );
         assert_that!(settings.exclude_patterns, elements_are![eq("node_modules/**")]);
         assert_that!(
             settings.translation_files.include_patterns,

--- a/src/framework.rs
+++ b/src/framework.rs
@@ -3,6 +3,7 @@
 pub mod i18next;
 pub mod next_intl;
 pub mod svelte_i18n;
+pub mod vue_i18n;
 
 use std::sync::OnceLock;
 
@@ -59,9 +60,10 @@ pub fn applicable_libraries(lang: ProgrammingLanguage) -> &'static [&'static dyn
             &[&i18next::I18next, &next_intl::NextIntl]
         }
         ProgrammingLanguage::JavaScript | ProgrammingLanguage::TypeScript => {
-            &[&i18next::I18next, &next_intl::NextIntl, &svelte_i18n::SvelteI18n]
+            &[&i18next::I18next, &next_intl::NextIntl, &svelte_i18n::SvelteI18n, &vue_i18n::VueI18n]
         }
         ProgrammingLanguage::Svelte => &[&svelte_i18n::SvelteI18n],
+        ProgrammingLanguage::Vue => &[&vue_i18n::VueI18n],
     }
 }
 
@@ -125,6 +127,7 @@ impl FrameworkConfig {
         static TS: OnceLock<FrameworkConfig> = OnceLock::new();
         static TSX: OnceLock<FrameworkConfig> = OnceLock::new();
         static SVELTE: OnceLock<FrameworkConfig> = OnceLock::new();
+        static VUE: OnceLock<FrameworkConfig> = OnceLock::new();
 
         match lang {
             ProgrammingLanguage::JavaScript => {
@@ -138,6 +141,7 @@ impl FrameworkConfig {
             ProgrammingLanguage::Svelte => {
                 SVELTE.get_or_init(|| Self::build(ProgrammingLanguage::Svelte))
             }
+            ProgrammingLanguage::Vue => VUE.get_or_init(|| Self::build(ProgrammingLanguage::Vue)),
         }
     }
 
@@ -165,9 +169,10 @@ mod tests {
     #[rstest]
     #[case::jsx(ProgrammingLanguage::Jsx, 2)]
     #[case::tsx(ProgrammingLanguage::Tsx, 2)]
-    #[case::js(ProgrammingLanguage::JavaScript, 3)]
-    #[case::ts(ProgrammingLanguage::TypeScript, 3)]
+    #[case::js(ProgrammingLanguage::JavaScript, 4)]
+    #[case::ts(ProgrammingLanguage::TypeScript, 4)]
     #[case::svelte(ProgrammingLanguage::Svelte, 1)]
+    #[case::vue(ProgrammingLanguage::Vue, 1)]
     fn applicable_libraries_count(#[case] lang: ProgrammingLanguage, #[case] expected: usize) {
         assert_that!(applicable_libraries(lang).len(), eq(expected));
     }
@@ -211,6 +216,19 @@ mod tests {
         assert_that!(config.allowed_trans_fn_methods, is_empty());
     }
 
+    #[rstest]
+    fn vue_config_has_only_vue_i18n() {
+        let config = FrameworkConfig::for_language(ProgrammingLanguage::Vue);
+
+        assert!(config.known_global_trans_fns.contains(&"$t"));
+        assert!(config.known_global_trans_fns.contains(&"$tc"));
+        assert!(config.known_global_trans_fns.contains(&"$te"));
+        assert!(config.known_global_trans_fns.contains(&"$tm"));
+        assert!(!config.known_global_trans_fns.contains(&"i18next.t"));
+        assert!(!config.known_global_trans_fns.contains(&"$_"));
+        assert_that!(config.allowed_trans_fn_methods, is_empty());
+    }
+
     // --- PluralStrategy merge ---
 
     #[rstest]
@@ -223,6 +241,12 @@ mod tests {
     #[rstest]
     fn svelte_plural_strategy_is_icu() {
         let config = FrameworkConfig::for_language(ProgrammingLanguage::Svelte);
+        assert_that!(config.plural_strategy, eq(PluralStrategy::Icu));
+    }
+
+    #[rstest]
+    fn vue_plural_strategy_is_icu() {
+        let config = FrameworkConfig::for_language(ProgrammingLanguage::Vue);
         assert_that!(config.plural_strategy, eq(PluralStrategy::Icu));
     }
 

--- a/src/framework/vue_i18n.rs
+++ b/src/framework/vue_i18n.rs
@@ -1,0 +1,26 @@
+//! vue-i18n library support.
+
+use super::{
+    I18nLibrary,
+    PluralStrategy,
+};
+
+#[derive(Debug, Clone, Copy)]
+pub struct VueI18n;
+
+impl I18nLibrary for VueI18n {
+    fn known_global_trans_fns(&self) -> &'static [&'static str] {
+        // $t, $tc, $te, $tm are global template functions in Options API and templates.
+        // Bare `t` is handled by the universal convention in is_trans_fn().
+        &["$t", "$tc", "$te", "$tm"]
+    }
+
+    fn allowed_trans_fn_methods(&self) -> &'static [&'static str] {
+        &[]
+    }
+
+    fn plural_strategy(&self) -> PluralStrategy {
+        // vue-i18n uses pipe-separated plurals in values, not key suffixes.
+        PluralStrategy::Icu
+    }
+}

--- a/src/input/source.rs
+++ b/src/input/source.rs
@@ -21,6 +21,7 @@ pub enum ProgrammingLanguage {
     TypeScript,
     Tsx,
     Svelte,
+    Vue,
 }
 
 impl ProgrammingLanguage {
@@ -34,6 +35,7 @@ impl ProgrammingLanguage {
             Some("jsx") => Some(Self::Jsx),
             Some("js") => Some(Self::JavaScript),
             Some("svelte") => Some(Self::Svelte),
+            Some("vue") => Some(Self::Vue),
             _ => None,
         }
     }
@@ -42,7 +44,9 @@ impl ProgrammingLanguage {
     pub fn tree_sitter_language(&self) -> tree_sitter::Language {
         match self {
             Self::JavaScript | Self::Jsx => tree_sitter_javascript::LANGUAGE.into(),
-            Self::TypeScript | Self::Svelte => tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
+            Self::TypeScript | Self::Svelte | Self::Vue => {
+                tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into()
+            }
             Self::Tsx => tree_sitter_typescript::LANGUAGE_TSX.into(),
         }
     }
@@ -61,6 +65,7 @@ mod tests {
     #[case::jsx("file.jsx", Some(ProgrammingLanguage::Jsx))]
     #[case::js("file.js", Some(ProgrammingLanguage::JavaScript))]
     #[case::svelte("file.svelte", Some(ProgrammingLanguage::Svelte))]
+    #[case::vue("file.vue", Some(ProgrammingLanguage::Vue))]
     #[case::multiple_dots("file.config.ts", Some(ProgrammingLanguage::TypeScript))]
     #[case::json("file.json", None)]
     #[case::no_ext("file", None)]

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -227,6 +227,22 @@ mod tests {
     }
 
     #[rstest]
+    fn analyze_source_vue_te_and_tm() {
+        let db = I18nDatabaseImpl::default();
+        let source = "<script setup>\nimport { useI18n } from 'vue-i18n'\nconst { t, te, tm } = useI18n()\nt('greeting')\nte('optional')\ntm('message')\n</script>";
+        let file = SourceFile::new(
+            &db,
+            "test.vue".to_string(),
+            source.to_string(),
+            ProgrammingLanguage::Vue,
+        );
+
+        let usages = analyze_source(&db, file, ".".to_string());
+        let keys: Vec<String> = usages.iter().map(|u| u.key(&db).text(&db).to_string()).collect();
+        assert_that!(keys, contains_each![eq("greeting"), eq("optional"), eq("message")]);
+    }
+
+    #[rstest]
     fn preprocess_vue_extracts_virtual_doc() {
         let text = "<script>\n  $t('key')\n</script>";
         let result = preprocess(text, ProgrammingLanguage::Vue);

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -1,6 +1,7 @@
 pub mod analyzer;
 pub mod position_map;
 pub mod svelte;
+pub mod vue;
 
 use std::borrow::Cow;
 
@@ -25,6 +26,13 @@ pub(crate) fn preprocess(text: &str, language: ProgrammingLanguage) -> SourcePre
     match language {
         ProgrammingLanguage::Svelte => {
             let extraction = svelte::extract(text);
+            SourcePreprocessed {
+                source: Cow::Owned(extraction.virtual_doc),
+                position_map: Some(extraction.position_map),
+            }
+        }
+        ProgrammingLanguage::Vue => {
+            let extraction = vue::extract(text);
             SourcePreprocessed {
                 source: Cow::Owned(extraction.virtual_doc),
                 position_map: Some(extraction.position_map),
@@ -166,6 +174,66 @@ mod tests {
         // The key 'key' should be remapped to original line 1 (inside <script>)
         let range = usages[0].range(&db);
         assert_that!(range.start.line, eq(1));
+    }
+
+    #[rstest]
+    fn analyze_source_vue_script_block() {
+        let db = I18nDatabaseImpl::default();
+        let source = "<script setup>\nimport { useI18n } from 'vue-i18n'\nconst { t } = useI18n()\nt('greeting')\n</script>";
+        let file = SourceFile::new(
+            &db,
+            "test.vue".to_string(),
+            source.to_string(),
+            ProgrammingLanguage::Vue,
+        );
+
+        let usages = analyze_source(&db, file, ".".to_string());
+        assert_that!(usages.len(), eq(1));
+        assert_that!(usages[0].key(&db).text(&db), eq("greeting"));
+    }
+
+    #[rstest]
+    fn analyze_source_vue_template_expression() {
+        let db = I18nDatabaseImpl::default();
+        let source = "<template><p>{{ $t('template.key') }}</p></template>";
+        let file = SourceFile::new(
+            &db,
+            "test.vue".to_string(),
+            source.to_string(),
+            ProgrammingLanguage::Vue,
+        );
+
+        let usages = analyze_source(&db, file, ".".to_string());
+        assert_that!(usages.len(), eq(1));
+        assert_that!(usages[0].key(&db).text(&db), eq("template.key"));
+    }
+
+    #[rstest]
+    fn analyze_source_vue_remaps_positions() {
+        let db = I18nDatabaseImpl::default();
+        let source = "<script>\n  $t('key')\n</script>";
+        let file = SourceFile::new(
+            &db,
+            "test.vue".to_string(),
+            source.to_string(),
+            ProgrammingLanguage::Vue,
+        );
+
+        let usages = analyze_source(&db, file, ".".to_string());
+        assert_that!(usages.len(), eq(1));
+
+        let range = usages[0].range(&db);
+        assert_that!(range.start.line, eq(1));
+    }
+
+    #[rstest]
+    fn preprocess_vue_extracts_virtual_doc() {
+        let text = "<script>\n  $t('key')\n</script>";
+        let result = preprocess(text, ProgrammingLanguage::Vue);
+
+        assert!(result.position_map.is_some());
+        assert!(matches!(result.source, Cow::Owned(_)));
+        assert!(result.source.contains("$t('key')"));
     }
 
     #[rstest]

--- a/src/syntax/analyzer/extractor.rs
+++ b/src/syntax/analyzer/extractor.rs
@@ -216,19 +216,21 @@ pub fn analyze_trans_fn_calls(
 
         match capture_name {
             CaptureName::GetTransFn => {
-                let Ok(trans_fn) =
+                let Ok(trans_fns) =
                     parse_get_trans_fn_captures(query, node, source_bytes, cap_names, config)
                 else {
                     continue;
                 };
 
-                cleanup_out_of_scopes(&mut scopes, &trans_fn.trans_fn_name, node);
+                for trans_fn in trans_fns {
+                    cleanup_out_of_scopes(&mut scopes, &trans_fn.trans_fn_name, node);
 
-                let scope_node = get_closest_node(node, &["statement_block", "jsx_element"])
-                    .unwrap_or(root_node);
+                    let scope_node = get_closest_node(node, &["statement_block", "jsx_element"])
+                        .unwrap_or(root_node);
 
-                let trans_fn_name = trans_fn.trans_fn_name.clone();
-                scopes.push_scope(trans_fn_name, ScopeInfo::new(scope_node, trans_fn));
+                    let trans_fn_name = trans_fn.trans_fn_name.clone();
+                    scopes.push_scope(trans_fn_name, ScopeInfo::new(scope_node, trans_fn));
+                }
             }
             CaptureName::CallTransFn => {
                 let Ok(call_trans_fn) = parse_call_trans_fn_captures(
@@ -467,8 +469,8 @@ fn parse_get_trans_fn_captures(
     source_bytes: &[u8],
     cap_names: &[&str],
     config: &FrameworkConfig,
-) -> Result<GetTransFnDetail, AnalyzerError> {
-    let mut trans_fn_name: Option<String> = None;
+) -> Result<Vec<GetTransFnDetail>, AnalyzerError> {
+    let mut trans_fn_names: Vec<String> = Vec::new();
     let mut namespace = None;
     let mut namespace_items: Vec<String> = Vec::new();
     let mut key_prefix = None;
@@ -494,7 +496,11 @@ fn parse_get_trans_fn_captures(
 
             match capture_name {
                 CaptureName::GetTransFnName => {
-                    trans_fn_name = extract_node_text(capture.node, source_bytes);
+                    if let Some(name) = extract_node_text(capture.node, source_bytes)
+                        && !trans_fn_names.contains(&name)
+                    {
+                        trans_fn_names.push(name);
+                    }
                 }
                 CaptureName::Namespace => {
                     namespace = extract_node_text(capture.node, source_bytes);
@@ -529,11 +535,21 @@ fn parse_get_trans_fn_captures(
         }
     }
 
-    let trans_fn_name = trans_fn_name.ok_or(AnalyzerError::ParseFailed)?;
+    if trans_fn_names.is_empty() {
+        return Err(AnalyzerError::ParseFailed);
+    }
 
     let namespaces = if namespace_items.is_empty() { None } else { Some(namespace_items) };
 
-    Ok(GetTransFnDetail { trans_fn_name, namespace, namespaces, key_prefix })
+    Ok(trans_fn_names
+        .into_iter()
+        .map(|name| GetTransFnDetail {
+            trans_fn_name: name,
+            namespace: namespace.clone(),
+            namespaces: namespaces.clone(),
+            key_prefix: key_prefix.clone(),
+        })
+        .collect())
 }
 
 /// Parses call translation function captures from a tree-sitter node

--- a/src/syntax/analyzer/query_loader.rs
+++ b/src/syntax/analyzer/query_loader.rs
@@ -40,10 +40,14 @@ const TS_QUERIES: &[QueryFile] = &[
 const SVELTE_I18N_QUERIES: &[QueryFile] =
     &[QueryFile { content: include_str!("../../../queries/svelte-i18n.scm"), name: "svelte-i18n" }];
 
+const VUE_I18N_QUERIES: &[QueryFile] =
+    &[QueryFile { content: include_str!("../../../queries/vue-i18n.scm"), name: "vue-i18n" }];
+
 static JS_QUERY_CACHE: OnceLock<Vec<Query>> = OnceLock::new();
 static TS_QUERY_CACHE: OnceLock<Vec<Query>> = OnceLock::new();
 static TSX_QUERY_CACHE: OnceLock<Vec<Query>> = OnceLock::new();
 static SVELTE_QUERY_CACHE: OnceLock<Vec<Query>> = OnceLock::new();
+static VUE_QUERY_CACHE: OnceLock<Vec<Query>> = OnceLock::new();
 
 fn parse_queries(language: ProgrammingLanguage) -> Vec<Query> {
     let tree_sitter_lang = language.tree_sitter_language();
@@ -52,19 +56,31 @@ fn parse_queries(language: ProgrammingLanguage) -> Vec<Query> {
         ProgrammingLanguage::JavaScript | ProgrammingLanguage::Jsx | ProgrammingLanguage::Tsx => {
             JS_QUERIES
         }
-        ProgrammingLanguage::TypeScript | ProgrammingLanguage::Svelte => TS_QUERIES,
+        ProgrammingLanguage::TypeScript
+        | ProgrammingLanguage::Svelte
+        | ProgrammingLanguage::Vue => TS_QUERIES,
     };
 
-    // svelte-i18n queries apply to JS/TS/Svelte (not JSX/TSX which are React-specific)
+    // Framework-specific queries loaded based on language
     let extra: &[QueryFile] = match language {
-        ProgrammingLanguage::JavaScript
-        | ProgrammingLanguage::TypeScript
-        | ProgrammingLanguage::Svelte => SVELTE_I18N_QUERIES,
+        ProgrammingLanguage::JavaScript | ProgrammingLanguage::TypeScript => {
+            // JS/TS get both svelte-i18n and vue-i18n queries
+            // (combined via chaining below with extra2)
+            SVELTE_I18N_QUERIES
+        }
+        ProgrammingLanguage::Svelte => SVELTE_I18N_QUERIES,
+        ProgrammingLanguage::Vue => VUE_I18N_QUERIES,
+        _ => &[],
+    };
+
+    let extra2: &[QueryFile] = match language {
+        ProgrammingLanguage::JavaScript | ProgrammingLanguage::TypeScript => VUE_I18N_QUERIES,
         _ => &[],
     };
 
     base.iter()
         .chain(extra)
+        .chain(extra2)
         .filter_map(|qf| {
             Query::new(&tree_sitter_lang, qf.content)
                 .map_err(|e| tracing::error!("Failed to parse {} query: {e:?}", qf.name))
@@ -88,6 +104,9 @@ pub fn load_queries(language: ProgrammingLanguage) -> &'static [Query] {
         }
         ProgrammingLanguage::Svelte => {
             SVELTE_QUERY_CACHE.get_or_init(|| parse_queries(ProgrammingLanguage::Svelte))
+        }
+        ProgrammingLanguage::Vue => {
+            VUE_QUERY_CACHE.get_or_init(|| parse_queries(ProgrammingLanguage::Vue))
         }
     }
 }

--- a/src/syntax/vue.rs
+++ b/src/syntax/vue.rs
@@ -293,8 +293,24 @@ fn extract_tag_attributes(
     }
 }
 
+/// Emit a synthetic `$t('key')` call, aligning the key position in the virtual
+/// document with `original_key_col` in the original file.
+fn emit_synthetic_t_call(
+    key: &str,
+    original_key_col: usize,
+    line_num: u32,
+    virtual_doc: &mut String,
+    position_map: &mut PositionMap,
+    virtual_line: &mut u32,
+) {
+    let synthetic = format!("$t('{key}')");
+    let key_offset_in_synthetic = synthetic.find(key).unwrap_or(4);
+    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+    let col_offset = original_key_col as i32 - key_offset_in_synthetic as i32;
+    push_expression(&synthetic, line_num, col_offset, virtual_doc, position_map, virtual_line);
+}
+
 /// Extract `<i18n-t keypath="key">`, `<I18nT keypath="key">`, `<i18n path="key">` components.
-/// Synthesizes `$t('key')` calls for detected keys.
 fn extract_i18n_component(
     tag_content: &str,
     tag_byte_offset: usize,
@@ -317,14 +333,10 @@ fn extract_i18n_component(
         if let Some(close_quote) = tag_content[value_start..].find('"') {
             let key = &tag_content[value_start..value_start + close_quote];
             if !key.is_empty() {
-                // Synthesize $t('key') call
-                let synthetic = format!("$t('{key}')");
-                #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-                let col_offset = (tag_byte_offset + value_start) as i32;
-                push_expression(
-                    &synthetic,
+                emit_synthetic_t_call(
+                    key,
+                    tag_byte_offset + value_start,
                     line_num,
-                    col_offset,
                     virtual_doc,
                     position_map,
                     virtual_line,
@@ -335,7 +347,6 @@ fn extract_i18n_component(
 }
 
 /// Extract `v-t="'key'"` or `v-t="{ path: 'key' }"` directive.
-/// Synthesizes `$t('key')` calls for detected keys.
 fn extract_v_t_directive(
     tag_content: &str,
     tag_byte_offset: usize,
@@ -344,7 +355,6 @@ fn extract_v_t_directive(
     position_map: &mut PositionMap,
     virtual_line: &mut u32,
 ) {
-    // Match v-t="..." attribute
     let search = "v-t=\"";
     let Some(vt_pos) = tag_content.find(search) else { return };
     let value_start = vt_pos + search.len();
@@ -358,21 +368,32 @@ fn extract_v_t_directive(
 
     // String syntax: v-t="'key'"
     if let Some(key) = extract_string_literal(trimmed) {
-        let synthetic = format!("$t('{key}')");
-        #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-        let col_offset = (tag_byte_offset + value_start) as i32;
-        push_expression(&synthetic, line_num, col_offset, virtual_doc, position_map, virtual_line);
+        // key starts after the opening quote: value_start + 1
+        let original_key_col = tag_byte_offset + value_start + 1;
+        emit_synthetic_t_call(
+            key,
+            original_key_col,
+            line_num,
+            virtual_doc,
+            position_map,
+            virtual_line,
+        );
         return;
     }
 
     // Object syntax: v-t="{ path: 'key' }"
     if trimmed.starts_with('{')
-        && let Some(key) = extract_object_path_value(trimmed)
+        && let Some((key, key_offset)) = extract_object_path_value_with_offset(value)
     {
-        let synthetic = format!("$t('{key}')");
-        #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-        let col_offset = (tag_byte_offset + value_start) as i32;
-        push_expression(&synthetic, line_num, col_offset, virtual_doc, position_map, virtual_line);
+        let original_key_col = tag_byte_offset + value_start + key_offset;
+        emit_synthetic_t_call(
+            key,
+            original_key_col,
+            line_num,
+            virtual_doc,
+            position_map,
+            virtual_line,
+        );
     }
 }
 
@@ -386,14 +407,22 @@ fn extract_string_literal(s: &str) -> Option<&str> {
     }
 }
 
-/// Extract the `path` property value from an object literal like `{ path: 'key' }`.
-fn extract_object_path_value(s: &str) -> Option<&str> {
-    // Simple parsing for `path: 'value'` or `path: "value"` within the object
+/// Extract the `path` property value and its byte offset from an object literal.
+/// Returns `(key, byte_offset_of_key_within_s)`.
+fn extract_object_path_value_with_offset(s: &str) -> Option<(&str, usize)> {
     let path_patterns = ["path:", "path :"];
     for pattern in path_patterns {
         if let Some(idx) = s.find(pattern) {
-            let after = s[idx + pattern.len()..].trim();
-            return extract_string_literal(after.split([',', '}']).next().unwrap_or("").trim());
+            let after_pattern = idx + pattern.len();
+            let after = s[after_pattern..].trim();
+            let trimmed_offset = after_pattern + (s[after_pattern..].len() - after.len());
+            let literal_part = after.split([',', '}']).next().unwrap_or("").trim();
+            if let Some(key) = extract_string_literal(literal_part) {
+                // key starts after the opening quote
+                let quote_pos = s[trimmed_offset..].find(['\'', '"']).unwrap_or(0);
+                let key_offset = trimmed_offset + quote_pos + 1;
+                return Some((key, key_offset));
+            }
         }
     }
     None
@@ -708,6 +737,61 @@ t('hello')
         let result = extract(vue);
 
         assert_that!(result.virtual_doc, contains_substring("$t('message.hello')"));
+    }
+
+    #[rstest]
+    fn extract_v_t_string_position_mapping() {
+        // <p v-t="'message.hello'"></p>
+        //         ^              ^
+        //         col 8 (quote)  col 22
+        // Key "message.hello" starts at col 9 in the original.
+        let vue = "<p v-t=\"'message.hello'\"></p>";
+        let result = extract(vue);
+
+        assert_that!(result.virtual_doc, contains_substring("$t('message.hello')"));
+
+        // In the virtual doc, "message.hello" is inside $t('message.hello')
+        // at character offset 4. The original key starts at column 9.
+        let virtual_range = Range {
+            start: Position { line: 0, character: 4 },
+            end: Position { line: 0, character: 17 },
+        };
+        let remapped = result.position_map.remap(virtual_range);
+        assert_that!(remapped.start.character, eq(9));
+    }
+
+    #[rstest]
+    fn extract_v_t_object_position_mapping() {
+        // <p v-t="{ path: 'message.goodbye' }"></p>
+        //                  ^
+        //                  col 17
+        let vue = "<p v-t=\"{ path: 'message.goodbye' }\"></p>";
+        let result = extract(vue);
+
+        assert_that!(result.virtual_doc, contains_substring("$t('message.goodbye')"));
+
+        let virtual_range = Range {
+            start: Position { line: 0, character: 4 },
+            end: Position { line: 0, character: 19 },
+        };
+        let remapped = result.position_map.remap(virtual_range);
+        assert_that!(remapped.start.character, eq(17));
+    }
+
+    #[rstest]
+    fn extract_i18n_t_keypath_position_mapping() {
+        // <i18n-t keypath="terms" tag="p"></i18n-t>
+        //                  ^
+        //                  col 17
+        let vue = "<i18n-t keypath=\"terms\" tag=\"p\"></i18n-t>";
+        let result = extract(vue);
+
+        let virtual_range = Range {
+            start: Position { line: 0, character: 4 },
+            end: Position { line: 0, character: 9 },
+        };
+        let remapped = result.position_map.remap(virtual_range);
+        assert_that!(remapped.start.character, eq(17));
     }
 
     // --- Skipping non-template regions ---

--- a/src/syntax/vue.rs
+++ b/src/syntax/vue.rs
@@ -1,0 +1,792 @@
+//! Extract JavaScript/TypeScript regions from `.vue` files.
+//!
+//! Vue SFC files mix HTML template, JS/TS script, and CSS. This module extracts
+//! JS/TS code from `<script>` blocks and template expressions, building a virtual
+//! document that can be parsed by tree-sitter TypeScript.
+
+use super::position_map::{
+    PositionMap,
+    PositionMapEntry,
+};
+
+/// Result of extracting JS/TS from a `.vue` file.
+#[derive(Debug)]
+pub struct VueExtraction {
+    /// Synthesized JS/TS source for tree-sitter parsing.
+    pub virtual_doc: String,
+    /// Maps virtual document positions back to original `.vue` file positions.
+    pub position_map: PositionMap,
+}
+
+/// Extract JS/TS regions from a Vue SFC source file.
+#[must_use]
+pub fn extract(source: &str) -> VueExtraction {
+    let mut virtual_doc = String::new();
+    let mut position_map = PositionMap::default();
+    let mut virtual_line: u32 = 0;
+
+    let lines: Vec<&str> = source.lines().collect();
+
+    // Phase 1: Extract <script> and <script setup> blocks
+    extract_script_blocks(&lines, &mut virtual_doc, &mut position_map, &mut virtual_line);
+
+    // Phase 2: Extract template expressions from non-script, non-style, non-i18n regions
+    extract_template_regions(&lines, &mut virtual_doc, &mut position_map, &mut virtual_line);
+
+    VueExtraction { virtual_doc, position_map }
+}
+
+/// Phase 1: Extract content from `<script>` and `<script setup>` blocks.
+fn extract_script_blocks(
+    lines: &[&str],
+    virtual_doc: &mut String,
+    position_map: &mut PositionMap,
+    virtual_line: &mut u32,
+) {
+    let mut in_script = false;
+    let mut in_style = false;
+    let mut in_i18n = false;
+
+    for (line_idx, line) in lines.iter().enumerate() {
+        #[allow(clippy::cast_possible_truncation)]
+        let line_num = line_idx as u32;
+        let trimmed = line.trim();
+
+        if !in_script && !in_style && !in_i18n {
+            if is_script_open_tag(trimmed) {
+                in_script = true;
+                if let Some(after_tag) = trimmed.split_once('>').map(|(_, rest)| rest)
+                    && !after_tag.is_empty()
+                    && !after_tag.starts_with("</script")
+                {
+                    let tag_prefix_len = line.find('>').map_or(0, |i| i + 1);
+                    push_line(
+                        after_tag,
+                        line_num,
+                        tag_prefix_len,
+                        virtual_doc,
+                        position_map,
+                        virtual_line,
+                    );
+                }
+                continue;
+            }
+            if trimmed.starts_with("<style") {
+                in_style = true;
+                continue;
+            }
+            if is_i18n_block_open(trimmed) {
+                in_i18n = true;
+                continue;
+            }
+        }
+
+        if in_style {
+            if trimmed.starts_with("</style") {
+                in_style = false;
+            }
+            continue;
+        }
+
+        if in_i18n {
+            if is_i18n_block_close(trimmed) {
+                in_i18n = false;
+            }
+            continue;
+        }
+
+        if in_script {
+            if trimmed.starts_with("</script") {
+                in_script = false;
+                continue;
+            }
+            push_line(line, line_num, 0, virtual_doc, position_map, virtual_line);
+        }
+    }
+}
+
+/// Phase 2: Extract template expressions from markup regions.
+fn extract_template_regions(
+    lines: &[&str],
+    virtual_doc: &mut String,
+    position_map: &mut PositionMap,
+    virtual_line: &mut u32,
+) {
+    let mut in_script = false;
+    let mut in_style = false;
+    let mut in_i18n = false;
+
+    for (line_idx, line) in lines.iter().enumerate() {
+        #[allow(clippy::cast_possible_truncation)]
+        let line_num = line_idx as u32;
+        let trimmed = line.trim();
+
+        // Track regions to skip
+        if is_script_open_tag(trimmed) {
+            in_script = true;
+        }
+        if in_script && trimmed.starts_with("</script") {
+            in_script = false;
+            continue;
+        }
+        if trimmed.starts_with("<style") {
+            in_style = true;
+        }
+        if in_style && trimmed.starts_with("</style") {
+            in_style = false;
+            continue;
+        }
+        if is_i18n_block_open(trimmed) {
+            in_i18n = true;
+        }
+        if in_i18n && is_i18n_block_close(trimmed) {
+            in_i18n = false;
+            continue;
+        }
+        if in_script || in_style || in_i18n {
+            continue;
+        }
+
+        // Extract from template line
+        extract_template_line(line, line_num, virtual_doc, position_map, virtual_line);
+    }
+}
+
+/// Extract expressions from a single template line.
+///
+/// Handles:
+/// - `{{ expr }}` mustache interpolation
+/// - `:attr="expr"` / `v-bind:attr="expr"` attribute bindings
+/// - `v-if="expr"`, `v-show="expr"`, `v-for="... in expr"`, `@event="expr"` directives
+/// - `<i18n-t keypath="key">` / `<I18nT keypath="key">` / `<i18n path="key">`
+/// - `v-t="'key'"` / `v-t="{ path: 'key' }"` directive
+fn extract_template_line(
+    line: &str,
+    line_num: u32,
+    virtual_doc: &mut String,
+    position_map: &mut PositionMap,
+    virtual_line: &mut u32,
+) {
+    let chars: Vec<char> = line.chars().collect();
+    let mut i = 0;
+
+    while i < chars.len() {
+        // Mustache interpolation: {{ expr }}
+        if chars.get(i).copied() == Some('{')
+            && chars.get(i + 1).copied() == Some('{')
+            && let Some(close) = find_mustache_close(&chars, i + 2)
+        {
+            let byte_start = char_offset_to_byte(line, i + 2);
+            let byte_end = char_offset_to_byte(line, close);
+            let expr = line[byte_start..byte_end].trim();
+            if !expr.is_empty() {
+                let whitespace_prefix =
+                    line[byte_start..byte_end].chars().take_while(|c| c.is_whitespace()).count();
+                #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+                let col_offset = (byte_start + whitespace_prefix) as i32;
+                push_expression(
+                    expr,
+                    line_num,
+                    col_offset,
+                    virtual_doc,
+                    position_map,
+                    virtual_line,
+                );
+            }
+            i = close + 2; // skip }}
+            continue;
+        }
+
+        // HTML tag attributes: look for directive/binding attributes
+        if chars.get(i).copied() == Some('<') && i + 1 < chars.len() && chars[i + 1].is_alphabetic()
+        {
+            let tag_end = find_tag_end(&chars, i);
+            let byte_start = char_offset_to_byte(line, i);
+            let byte_end = char_offset_to_byte(line, tag_end.unwrap_or(chars.len()));
+            let tag_content = &line[byte_start..byte_end];
+
+            extract_tag_attributes(
+                tag_content,
+                byte_start,
+                line_num,
+                virtual_doc,
+                position_map,
+                virtual_line,
+            );
+
+            i = tag_end.unwrap_or(chars.len());
+            continue;
+        }
+
+        i += 1;
+    }
+}
+
+/// Extract directive/binding attributes from an HTML tag.
+fn extract_tag_attributes(
+    tag_content: &str,
+    tag_byte_offset: usize,
+    line_num: u32,
+    virtual_doc: &mut String,
+    position_map: &mut PositionMap,
+    virtual_line: &mut u32,
+) {
+    // Handle <i18n-t keypath="key"> / <I18nT keypath="key"> / <i18n path="key">
+    extract_i18n_component(
+        tag_content,
+        tag_byte_offset,
+        line_num,
+        virtual_doc,
+        position_map,
+        virtual_line,
+    );
+
+    // Handle v-t directive
+    extract_v_t_directive(
+        tag_content,
+        tag_byte_offset,
+        line_num,
+        virtual_doc,
+        position_map,
+        virtual_line,
+    );
+
+    // Handle Vue directive/binding expressions: :attr="expr", v-if="expr", @event="expr"
+    let mut pos = 0;
+    let bytes = tag_content.as_bytes();
+    while pos < bytes.len() {
+        // Look for directive attributes
+        let is_directive = matches!(bytes.get(pos), Some(b':' | b'@'))
+            || (bytes.get(pos) == Some(&b'v')
+                && bytes.get(pos + 1) == Some(&b'-')
+                && !tag_content[pos..].starts_with("v-t=")
+                && !tag_content[pos..].starts_with("v-t "));
+
+        if is_directive {
+            // Find ="..."
+            if let Some(eq_pos) = tag_content[pos..].find('=') {
+                let abs_eq = pos + eq_pos;
+                if abs_eq + 1 < bytes.len()
+                    && bytes[abs_eq + 1] == b'"'
+                    && let Some(close_quote) = tag_content[abs_eq + 2..].find('"')
+                {
+                    let expr_start = abs_eq + 2;
+                    let expr_end = abs_eq + 2 + close_quote;
+                    let expr = &tag_content[expr_start..expr_end];
+                    if !expr.is_empty() {
+                        #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+                        let col_offset = (tag_byte_offset + expr_start) as i32;
+                        push_expression(
+                            expr,
+                            line_num,
+                            col_offset,
+                            virtual_doc,
+                            position_map,
+                            virtual_line,
+                        );
+                    }
+                    pos = expr_end + 1;
+                    continue;
+                }
+            }
+        }
+        pos += 1;
+    }
+}
+
+/// Extract `<i18n-t keypath="key">`, `<I18nT keypath="key">`, `<i18n path="key">` components.
+/// Synthesizes `$t('key')` calls for detected keys.
+fn extract_i18n_component(
+    tag_content: &str,
+    tag_byte_offset: usize,
+    line_num: u32,
+    virtual_doc: &mut String,
+    position_map: &mut PositionMap,
+    virtual_line: &mut u32,
+) {
+    let tag_name = tag_content.split_whitespace().next().unwrap_or("").trim_start_matches('<');
+
+    let attr_name = match tag_name {
+        "i18n-t" | "I18nT" => "keypath",
+        "i18n" => "path",
+        _ => return,
+    };
+
+    let search = format!("{attr_name}=\"");
+    if let Some(attr_pos) = tag_content.find(&search) {
+        let value_start = attr_pos + search.len();
+        if let Some(close_quote) = tag_content[value_start..].find('"') {
+            let key = &tag_content[value_start..value_start + close_quote];
+            if !key.is_empty() {
+                // Synthesize $t('key') call
+                let synthetic = format!("$t('{key}')");
+                #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+                let col_offset = (tag_byte_offset + value_start) as i32;
+                push_expression(
+                    &synthetic,
+                    line_num,
+                    col_offset,
+                    virtual_doc,
+                    position_map,
+                    virtual_line,
+                );
+            }
+        }
+    }
+}
+
+/// Extract `v-t="'key'"` or `v-t="{ path: 'key' }"` directive.
+/// Synthesizes `$t('key')` calls for detected keys.
+fn extract_v_t_directive(
+    tag_content: &str,
+    tag_byte_offset: usize,
+    line_num: u32,
+    virtual_doc: &mut String,
+    position_map: &mut PositionMap,
+    virtual_line: &mut u32,
+) {
+    // Match v-t="..." attribute
+    let search = "v-t=\"";
+    let Some(vt_pos) = tag_content.find(search) else { return };
+    let value_start = vt_pos + search.len();
+    let Some(close_quote) = tag_content[value_start..].find('"') else { return };
+    let value = &tag_content[value_start..value_start + close_quote];
+
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return;
+    }
+
+    // String syntax: v-t="'key'"
+    if let Some(key) = extract_string_literal(trimmed) {
+        let synthetic = format!("$t('{key}')");
+        #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+        let col_offset = (tag_byte_offset + value_start) as i32;
+        push_expression(&synthetic, line_num, col_offset, virtual_doc, position_map, virtual_line);
+        return;
+    }
+
+    // Object syntax: v-t="{ path: 'key' }"
+    if trimmed.starts_with('{')
+        && let Some(key) = extract_object_path_value(trimmed)
+    {
+        let synthetic = format!("$t('{key}')");
+        #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+        let col_offset = (tag_byte_offset + value_start) as i32;
+        push_expression(&synthetic, line_num, col_offset, virtual_doc, position_map, virtual_line);
+    }
+}
+
+/// Extract a string literal value from `'key'` or `"key"`.
+fn extract_string_literal(s: &str) -> Option<&str> {
+    let s = s.trim();
+    if (s.starts_with('\'') && s.ends_with('\'')) || (s.starts_with('"') && s.ends_with('"')) {
+        Some(&s[1..s.len() - 1])
+    } else {
+        None
+    }
+}
+
+/// Extract the `path` property value from an object literal like `{ path: 'key' }`.
+fn extract_object_path_value(s: &str) -> Option<&str> {
+    // Simple parsing for `path: 'value'` or `path: "value"` within the object
+    let path_patterns = ["path:", "path :"];
+    for pattern in path_patterns {
+        if let Some(idx) = s.find(pattern) {
+            let after = s[idx + pattern.len()..].trim();
+            return extract_string_literal(after.split([',', '}']).next().unwrap_or("").trim());
+        }
+    }
+    None
+}
+
+/// Check if a trimmed line is a `<script>` or `<script setup>` opening tag.
+fn is_script_open_tag(trimmed: &str) -> bool {
+    trimmed.starts_with("<script") && trimmed.contains('>')
+}
+
+/// Check if a trimmed line opens an `<i18n>` custom block (not `<i18n-t>` component).
+fn is_i18n_block_open(trimmed: &str) -> bool {
+    if !trimmed.starts_with("<i18n") {
+        return false;
+    }
+    // <i18n>, <i18n , <i18n\t — but NOT <i18n-t>, <i18n-d>, <i18n-n>
+    let after = &trimmed[5..];
+    after.is_empty() || after.starts_with('>') || after.starts_with(' ') || after.starts_with('/')
+}
+
+/// Check if a trimmed line closes an `<i18n>` custom block.
+fn is_i18n_block_close(trimmed: &str) -> bool {
+    trimmed.starts_with("</i18n>") || trimmed.starts_with("</i18n ")
+}
+
+fn push_line(
+    content: &str,
+    line_num: u32,
+    byte_offset: usize,
+    virtual_doc: &mut String,
+    position_map: &mut PositionMap,
+    virtual_line: &mut u32,
+) {
+    virtual_doc.push_str(content);
+    virtual_doc.push('\n');
+    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+    let column_offset = byte_offset as i32;
+    position_map.push(PositionMapEntry {
+        virtual_line_start: *virtual_line,
+        virtual_line_count: 1,
+        original_line: line_num,
+        column_offset,
+    });
+    *virtual_line += 1;
+}
+
+fn push_expression(
+    expr: &str,
+    line_num: u32,
+    column_offset: i32,
+    virtual_doc: &mut String,
+    position_map: &mut PositionMap,
+    virtual_line: &mut u32,
+) {
+    virtual_doc.push_str(expr);
+    virtual_doc.push('\n');
+    position_map.push(PositionMapEntry {
+        virtual_line_start: *virtual_line,
+        virtual_line_count: 1,
+        original_line: line_num,
+        column_offset,
+    });
+    *virtual_line += 1;
+}
+
+/// Find `}}` closing mustache, handling nested braces and strings.
+fn find_mustache_close(chars: &[char], start: usize) -> Option<usize> {
+    let mut i = start;
+    let mut in_string = false;
+    let mut string_char = ' ';
+
+    while i + 1 < chars.len() {
+        let c = chars[i];
+
+        if in_string {
+            if c == string_char && chars.get(i.wrapping_sub(1)).copied() != Some('\\') {
+                in_string = false;
+            }
+            i += 1;
+            continue;
+        }
+
+        if c == '\'' || c == '"' || c == '`' {
+            in_string = true;
+            string_char = c;
+            i += 1;
+            continue;
+        }
+
+        if c == '}' && chars.get(i + 1).copied() == Some('}') {
+            return Some(i);
+        }
+
+        i += 1;
+    }
+    None
+}
+
+/// Find the end of an HTML tag (the `>` character), handling quoted attributes.
+fn find_tag_end(chars: &[char], start: usize) -> Option<usize> {
+    let mut i = start + 1;
+    let mut in_quote = false;
+    let mut quote_char = ' ';
+
+    while i < chars.len() {
+        let c = chars[i];
+
+        if in_quote {
+            if c == quote_char {
+                in_quote = false;
+            }
+            i += 1;
+            continue;
+        }
+
+        if c == '"' || c == '\'' {
+            in_quote = true;
+            quote_char = c;
+            i += 1;
+            continue;
+        }
+
+        if c == '>' {
+            return Some(i + 1);
+        }
+
+        i += 1;
+    }
+    None
+}
+
+/// Convert a character offset to a byte offset.
+fn char_offset_to_byte(s: &str, char_offset: usize) -> usize {
+    s.char_indices().nth(char_offset).map_or(s.len(), |(byte_idx, _)| byte_idx)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::indexing_slicing, clippy::expect_used, clippy::panic)]
+mod tests {
+    use googletest::prelude::*;
+    use rstest::*;
+    use tower_lsp::lsp_types::{
+        Position,
+        Range,
+    };
+
+    use super::*;
+
+    // --- Script block extraction ---
+
+    #[rstest]
+    fn extract_script_block_basic() {
+        let vue = "\
+<script>
+import { useI18n } from 'vue-i18n'
+const { t } = useI18n()
+t('hello')
+</script>
+<template><p>{{ $t('world') }}</p></template>";
+        let result = extract(vue);
+
+        assert_that!(result.virtual_doc, contains_substring("t('hello')"));
+        assert_that!(result.virtual_doc, contains_substring("useI18n"));
+    }
+
+    #[rstest]
+    fn extract_script_setup() {
+        let vue = "<script setup lang=\"ts\">\nconst { t } = useI18n()\nt('typed')\n</script>";
+        let result = extract(vue);
+
+        assert_that!(result.virtual_doc, contains_substring("t('typed')"));
+    }
+
+    #[rstest]
+    fn extract_both_script_blocks() {
+        let vue = "\
+<script>
+export default { name: 'MyComponent' }
+</script>
+<script setup>
+const { t } = useI18n()
+t('hello')
+</script>";
+        let result = extract(vue);
+
+        assert_that!(result.virtual_doc, contains_substring("export default"));
+        assert_that!(result.virtual_doc, contains_substring("t('hello')"));
+    }
+
+    #[rstest]
+    fn extract_no_script_block() {
+        let vue = "<template><p>{{ $t('only_template') }}</p></template>";
+        let result = extract(vue);
+
+        assert_that!(result.virtual_doc, contains_substring("$t('only_template')"));
+    }
+
+    #[rstest]
+    fn extract_script_position_mapping() {
+        let vue = "<script>\n  t('key')\n</script>";
+        let result = extract(vue);
+
+        let virtual_range = Range {
+            start: Position { line: 0, character: 2 },
+            end: Position { line: 0, character: 10 },
+        };
+        let remapped = result.position_map.remap(virtual_range);
+        assert_that!(remapped.start.line, eq(1));
+        assert_that!(remapped.start.character, eq(2));
+    }
+
+    // --- Template expression extraction ---
+
+    #[rstest]
+    fn extract_mustache_basic() {
+        let vue = "<template><p>{{ $t('greeting') }}</p></template>";
+        let result = extract(vue);
+
+        assert_that!(result.virtual_doc, contains_substring("$t('greeting')"));
+    }
+
+    #[rstest]
+    fn extract_mustache_with_values() {
+        let vue = "<template><p>{{ $t('welcome', { name: 'World' }) }}</p></template>";
+        let result = extract(vue);
+
+        assert_that!(result.virtual_doc, contains_substring("$t('welcome'"));
+    }
+
+    #[rstest]
+    fn extract_mustache_ternary() {
+        let vue = "<template><p>{{ condition ? $t('a') : $t('b') }}</p></template>";
+        let result = extract(vue);
+
+        assert_that!(result.virtual_doc, contains_substring("$t('a')"));
+        assert_that!(result.virtual_doc, contains_substring("$t('b')"));
+    }
+
+    // --- Directive/binding extraction ---
+
+    #[rstest]
+    fn extract_v_bind_shorthand() {
+        let vue = "<template><input :placeholder=\"$t('form.placeholder')\" /></template>";
+        let result = extract(vue);
+
+        assert_that!(result.virtual_doc, contains_substring("$t('form.placeholder')"));
+    }
+
+    #[rstest]
+    fn extract_v_if_directive() {
+        let vue = "<template><span v-if=\"$te('optional')\">text</span></template>";
+        let result = extract(vue);
+
+        assert_that!(result.virtual_doc, contains_substring("$te('optional')"));
+    }
+
+    #[rstest]
+    fn extract_v_show_directive() {
+        let vue = "<template><span v-show=\"$te('visible')\">text</span></template>";
+        let result = extract(vue);
+
+        assert_that!(result.virtual_doc, contains_substring("$te('visible')"));
+    }
+
+    #[rstest]
+    fn extract_event_handler() {
+        let vue = "<template><button @click=\"alert($t('msg'))\">Click</button></template>";
+        let result = extract(vue);
+
+        assert_that!(result.virtual_doc, contains_substring("alert($t('msg'))"));
+    }
+
+    // --- i18n-t component extraction ---
+
+    #[rstest]
+    fn extract_i18n_t_keypath() {
+        let vue = "<template><i18n-t keypath=\"terms\" tag=\"p\"></i18n-t></template>";
+        let result = extract(vue);
+
+        assert_that!(result.virtual_doc, contains_substring("$t('terms')"));
+    }
+
+    #[rstest]
+    fn extract_i18n_t_pascal_case() {
+        let vue = "<template><I18nT keypath=\"terms\" tag=\"p\"></I18nT></template>";
+        let result = extract(vue);
+
+        assert_that!(result.virtual_doc, contains_substring("$t('terms')"));
+    }
+
+    #[rstest]
+    fn extract_i18n_v8_path() {
+        let vue = "<template><i18n path=\"terms\" tag=\"p\"></i18n></template>";
+        let result = extract(vue);
+
+        assert_that!(result.virtual_doc, contains_substring("$t('terms')"));
+    }
+
+    // --- v-t directive extraction ---
+
+    #[rstest]
+    fn extract_v_t_string_syntax() {
+        let vue = "<template><p v-t=\"'message.hello'\"></p></template>";
+        let result = extract(vue);
+
+        assert_that!(result.virtual_doc, contains_substring("$t('message.hello')"));
+    }
+
+    #[rstest]
+    fn extract_v_t_object_syntax() {
+        let vue = "<template><p v-t=\"{ path: 'message.hello', args: { name: userName } }\"></p></template>";
+        let result = extract(vue);
+
+        assert_that!(result.virtual_doc, contains_substring("$t('message.hello')"));
+    }
+
+    // --- Skipping non-template regions ---
+
+    #[rstest]
+    fn extract_ignores_style_block() {
+        let vue = "\
+<style>
+  .foo { color: red; }
+</style>
+<template><p>{{ $t('key') }}</p></template>";
+        let result = extract(vue);
+
+        assert_that!(result.virtual_doc, contains_substring("$t('key')"));
+        assert_that!(result.virtual_doc, not(contains_substring("color")));
+    }
+
+    #[rstest]
+    fn extract_ignores_i18n_block() {
+        let vue = "\
+<i18n>
+{ \"en\": { \"title\": \"Hello\" } }
+</i18n>
+<template><p>{{ $t('title') }}</p></template>";
+        let result = extract(vue);
+
+        assert_that!(result.virtual_doc, contains_substring("$t('title')"));
+        assert_that!(result.virtual_doc, not(contains_substring("Hello")));
+    }
+
+    // --- Combined extraction ---
+
+    #[rstest]
+    fn extract_script_and_template_combined() {
+        let vue = "\
+<script setup>
+import { useI18n } from 'vue-i18n'
+const { t } = useI18n()
+const msg = t('script_key')
+</script>
+<template><p>{{ $t('template_key') }}</p></template>";
+        let result = extract(vue);
+
+        assert_that!(result.virtual_doc, contains_substring("t('script_key')"));
+        assert_that!(result.virtual_doc, contains_substring("$t('template_key')"));
+    }
+
+    #[rstest]
+    fn extract_full_vue_component() {
+        let vue = "\
+<script setup lang=\"ts\">
+import { useI18n } from 'vue-i18n'
+const { t, te } = useI18n()
+</script>
+
+<template>
+  <div>
+    <h1>{{ $t('page.title') }}</h1>
+    <input :placeholder=\"$t('form.placeholder')\" />
+    <span v-if=\"$te('optional')\">{{ $t('optional') }}</span>
+    <i18n-t keypath=\"terms\" tag=\"p\">
+      <template #link><a href=\"/tos\">{{ $t('tos') }}</a></template>
+    </i18n-t>
+    <p v-t=\"'message.hello'\"></p>
+  </div>
+</template>
+
+<style scoped>
+.title { color: red; }
+</style>";
+        let result = extract(vue);
+
+        assert_that!(result.virtual_doc, contains_substring("useI18n"));
+        assert_that!(result.virtual_doc, contains_substring("$t('page.title')"));
+        assert_that!(result.virtual_doc, contains_substring("$t('form.placeholder')"));
+        assert_that!(result.virtual_doc, contains_substring("$te('optional')"));
+        assert_that!(result.virtual_doc, contains_substring("$t('terms')"));
+        assert_that!(result.virtual_doc, contains_substring("$t('message.hello')"));
+        assert_that!(result.virtual_doc, not(contains_substring("color")));
+    }
+}

--- a/src/syntax/vue.rs
+++ b/src/syntax/vue.rs
@@ -198,7 +198,7 @@ fn extract_template_line(
         }
 
         // HTML tag attributes: look for directive/binding attributes
-        if chars.get(i).copied() == Some('<') && i + 1 < chars.len() && chars[i + 1].is_alphabetic()
+        if chars.get(i).copied() == Some('<') && chars.get(i + 1).is_some_and(|c| c.is_alphabetic())
         {
             let tag_end = find_tag_end(&chars, i);
             let byte_start = char_offset_to_byte(line, i);
@@ -266,8 +266,7 @@ fn extract_tag_attributes(
             // Find ="..."
             if let Some(eq_pos) = tag_content[pos..].find('=') {
                 let abs_eq = pos + eq_pos;
-                if abs_eq + 1 < bytes.len()
-                    && bytes[abs_eq + 1] == b'"'
+                if bytes.get(abs_eq + 1) == Some(&b'"')
                     && let Some(close_quote) = tag_content[abs_eq + 2..].find('"')
                 {
                     let expr_start = abs_eq + 2;
@@ -466,8 +465,10 @@ fn find_mustache_close(chars: &[char], start: usize) -> Option<usize> {
     let mut in_string = false;
     let mut string_char = ' ';
 
-    while i + 1 < chars.len() {
-        let c = chars[i];
+    while let Some(&c) = chars.get(i) {
+        if i + 1 >= chars.len() {
+            break;
+        }
 
         if in_string {
             if c == string_char && chars.get(i.wrapping_sub(1)).copied() != Some('\\') {
@@ -499,9 +500,7 @@ fn find_tag_end(chars: &[char], start: usize) -> Option<usize> {
     let mut in_quote = false;
     let mut quote_char = ' ';
 
-    while i < chars.len() {
-        let c = chars[i];
-
+    while let Some(&c) = chars.get(i) {
         if in_quote {
             if c == quote_char {
                 in_quote = false;


### PR DESCRIPTION
## Summary

- Add vue-i18n support (v8/v9+), the de facto i18n library for Vue.js
- Implement Vue SFC extraction: `<script>`, `<script setup>`, template mustache `{{ }}`, directive bindings (`:attr`, `v-if`, `v-show`, `@event`), `<i18n-t>`/`<I18nT>` components, `v-t` directive
- Add tree-sitter queries for `useI18n()` destructuring and `this.$t()` patterns
- Register `VueI18n` framework with `$t`, `$tc`, `$te`, `$tm` global functions and ICU plural strategy
- Add `.vue` to default `include_patterns`

Also covers `petite-vue-i18n` and `@nuxtjs/i18n` (same API surface).

### New files
| File | Description |
|---|---|
| `src/framework/vue_i18n.rs` | `VueI18n` implementing `I18nLibrary` trait |
| `src/syntax/vue.rs` | Vue SFC extraction (script + template) |
| `queries/vue-i18n.scm` | Tree-sitter queries for vue-i18n patterns |
| `playground/vue-i18n/` | Demo project for testing |

### Modified files
| File | Changes |
|---|---|
| `src/input/source.rs` | `ProgrammingLanguage::Vue` variant |
| `src/framework.rs` | Register `vue_i18n` module |
| `src/syntax.rs` | Vue branch in `preprocess()` |
| `src/syntax/analyzer/query_loader.rs` | Vue query loading and caching |
| `src/config/types.rs` | `.vue` in default include patterns |
| `docs/supported-syntax.md` | vue-i18n documentation section |

### Not included (follow-up)
- `<i18n>` custom block as translation source
- Linked messages (`@:key`) detection
- Scope-aware diagnostics (local vs global)

## Test plan
- [x] All 480 existing + new tests pass
- [x] Clippy clean (no warnings)
- [x] Format clean (cargo +nightly fmt)
- [x] Manual testing with playground/vue-i18n/ project

Closes #4