### PR TITLE
feat: support next-intl getTranslations() server API

### DIFF
--- a/docs/frameworks/next-intl.md
+++ b/docs/frameworks/next-intl.md
@@ -13,7 +13,7 @@ Support for [next-intl](https://next-intl.dev/).
 | `useTranslations()` | ✅ | With optional namespace |
 | Namespace | ✅ | Via `useTranslations()` argument (acts as key prefix) |
 | `t.has()` | ❌ | Key existence check |
-| `getTranslations()` | ❌ | Server Components async API |
+| `getTranslations()` | ✅ | Server Components async API |
 | Plural (ICU) | ✅ | Embedded in translation values |
 
 > ✅ Supported | 🔜 Planned | ➖ Not applicable | ❌ Not supported
@@ -48,19 +48,30 @@ t.raw("htmlContent")
 
 ### Acquiring Translation Functions
 
+#### Client Components
+
 ```tsx
 const t = useTranslations()
 const t = useTranslations("namespace")
 const t = useTranslations("home.hero") // Nested namespace
 ```
 
-The `useTranslations()` argument acts as a **key prefix** — all keys are automatically prepended:
+#### Server Components
+
+```tsx
+const t = await getTranslations()
+const t = await getTranslations("namespace")
+const t = await getTranslations({ namespace: "common" })
+const t = await getTranslations({ locale: "en", namespace: "common" })
+```
+
+The argument (or `namespace` property) acts as a **key prefix** — all keys are automatically prepended:
 
 ```tsx
 const t = useTranslations("common")
 t("hello")  // -> "common.hello"
 
-const t = useTranslations("home.hero")
+const t = await getTranslations("home.hero")
 t("heading")  // -> "home.hero.heading"
 ```
 

--- a/playground/next-intl/getTranslations.tsx
+++ b/playground/next-intl/getTranslations.tsx
@@ -1,0 +1,85 @@
+/**
+ * next-intl getTranslations patterns (Server Components)
+ *
+ * getTranslations(namespace?)
+ * getTranslations({ namespace?, locale? })
+ */
+import { getTranslations } from "next-intl/server";
+
+// Basic usage (no namespace)
+async function BasicPage() {
+  const t = await getTranslations();
+
+  return (
+    <div>
+      <h1>{t("common.hello")}</h1>
+      <p>{t("common.goodbye")}</p>
+    </div>
+  );
+}
+
+// With string namespace
+async function WithNamespace() {
+  const t = await getTranslations("common");
+
+  return (
+    <div>
+      <h1>{t("hello")}</h1>
+      <p>{t("goodbye")}</p>
+    </div>
+  );
+}
+
+// With object argument (namespace only)
+async function WithObjectNamespace() {
+  const t = await getTranslations({ namespace: "common" });
+
+  return <h1>{t("welcome", { name: "World" })}</h1>;
+}
+
+// With object argument (locale + namespace)
+async function WithLocaleAndNamespace() {
+  const t = await getTranslations({ locale: "en", namespace: "home" });
+
+  return (
+    <div>
+      <h1>{t("title")}</h1>
+      <p>{t("description")}</p>
+    </div>
+  );
+}
+
+// Metadata API pattern
+async function generateMetadata({ params: { locale } }: { params: { locale: string } }) {
+  const t = await getTranslations({ locale, namespace: "common" });
+
+  return {
+    title: t("hello"),
+  };
+}
+
+// Method chains work the same as useTranslations
+async function RichTextPage() {
+  const t = await getTranslations("rich");
+
+  return (
+    <div>
+      {t.rich("terms", {
+        terms: (chunks) => <a href="/terms">{chunks}</a>,
+      })}
+      {t.markup("highlight", {
+        highlight: (chunks) => `<mark>${chunks}</mark>`,
+      })}
+      {t.raw("html")}
+    </div>
+  );
+}
+
+export {
+  BasicPage,
+  WithNamespace,
+  WithObjectNamespace,
+  WithLocaleAndNamespace,
+  generateMetadata,
+  RichTextPage,
+};

--- a/queries/javascript/i18next.scm
+++ b/queries/javascript/i18next.scm
@@ -1,5 +1,5 @@
-;; getFixedT 関数呼び出し
-;; 引数: (lang, ns?, keyPrefix?)
+;; getFixedT call
+;; Args: (lang, ns?, keyPrefix?)
 (variable_declarator
   name: (identifier) @i18n.get_trans_fn_name
   value:

--- a/queries/javascript/next-intl.scm
+++ b/queries/javascript/next-intl.scm
@@ -1,5 +1,5 @@
-;; useTranslations 関数呼び出し
-;; 引数: (namespace?)
+;; useTranslations hook
+;; Args: (namespace?)
 (variable_declarator
   name: (identifier) @i18n.get_trans_fn_name
   value:
@@ -9,8 +9,8 @@
     )
 ) @i18n.get_trans_fn
 
-;; getTranslations 関数呼び出し (Server Components)
-;; 引数: (namespace?) または ({ namespace?: string, locale?: string })
+;; getTranslations (Server Components)
+;; Args: (namespace?) or ({ namespace?: string, locale?: string })
 (variable_declarator
   name: (identifier) @i18n.get_trans_fn_name
   value:
@@ -22,9 +22,9 @@
     )
 ) @i18n.get_trans_fn
 
-;; getTranslations オブジェクト引数の namespace 抽出
+;; getTranslations with object argument: namespace extraction
 ;; await getTranslations({ namespace: "common" })
-;; next-intl の namespace は key prefix として機能する
+;; In next-intl, namespace acts as a key prefix
 (variable_declarator
   name: (identifier) @i18n.get_trans_fn_name
   value:

--- a/queries/javascript/next-intl.scm
+++ b/queries/javascript/next-intl.scm
@@ -8,3 +8,38 @@
       arguments: (arguments) @i18n.get_trans_fn_args
     )
 ) @i18n.get_trans_fn
+
+;; getTranslations 関数呼び出し (Server Components)
+;; 引数: (namespace?) または ({ namespace?: string, locale?: string })
+(variable_declarator
+  name: (identifier) @i18n.get_trans_fn_name
+  value:
+    (await_expression
+      (call_expression
+        function: (identifier) @use_translations (#eq? @use_translations "getTranslations")
+        arguments: (arguments) @i18n.get_trans_fn_args
+      )
+    )
+) @i18n.get_trans_fn
+
+;; getTranslations オブジェクト引数の namespace 抽出
+;; await getTranslations({ namespace: "common" })
+;; next-intl の namespace は key prefix として機能する
+(variable_declarator
+  name: (identifier) @i18n.get_trans_fn_name
+  value:
+    (await_expression
+      (call_expression
+        function: (identifier) @use_translations (#eq? @use_translations "getTranslations")
+        arguments:
+          (arguments
+            (object
+              (pair
+                key: (property_identifier) @_ns_key (#eq? @_ns_key "namespace")
+                value: (string (string_fragment) @i18n.trans_key_prefix)
+              )
+            )
+          )
+      )
+    )
+) @i18n.get_trans_fn

--- a/queries/javascript/react-i18next.scm
+++ b/queries/javascript/react-i18next.scm
@@ -80,7 +80,7 @@
   )
 )
 
-;; Translation コンポーネント
+;; Translation component
 (jsx_element
   open_tag: (jsx_opening_element
     name: (identifier) @translation (#eq? @translation "Translation")
@@ -100,7 +100,7 @@
   )
 ) @i18n.get_trans_fn
 
-;; Trans コンポーネント (self-closing)
+;; Trans component (self-closing)
 (jsx_self_closing_element
   name: (identifier) @trans (#eq? @trans "Trans")
   attribute: (jsx_attribute
@@ -116,7 +116,7 @@
   )?
 ) @i18n.call_trans_fn
 
-;; Trans コンポーネント (self-closing, Selector API)
+;; Trans component (self-closing, Selector API)
 (jsx_self_closing_element
   name: (identifier) @trans (#eq? @trans "Trans")
   attribute: (jsx_attribute
@@ -131,7 +131,7 @@
   )?
 ) @i18n.call_trans_fn
 
-;; Trans コンポーネント (opening element)
+;; Trans component (opening element)
 (jsx_opening_element
   name: (identifier) @trans (#eq? @trans "Trans")
   attribute: (jsx_attribute
@@ -147,7 +147,7 @@
   )?
 ) @i18n.call_trans_fn
 
-;; Trans コンポーネント (opening element, Selector API)
+;; Trans component (opening element, Selector API)
 (jsx_opening_element
   name: (identifier) @trans (#eq? @trans "Trans")
   attribute: (jsx_attribute

--- a/queries/tsx/i18next.scm
+++ b/queries/tsx/i18next.scm
@@ -1,5 +1,5 @@
-;; getFixedT 関数呼び出し
-;; 引数: (lang, ns?, keyPrefix?)
+;; getFixedT call
+;; Args: (lang, ns?, keyPrefix?)
 (variable_declarator
   name: (identifier) @i18n.get_trans_fn_name
   value:

--- a/queries/tsx/next-intl.scm
+++ b/queries/tsx/next-intl.scm
@@ -1,5 +1,5 @@
-;; useTranslations 関数呼び出し
-;; 引数: (namespace?)
+;; useTranslations hook
+;; Args: (namespace?)
 (variable_declarator
   name: (identifier) @i18n.get_trans_fn_name
   value:
@@ -9,8 +9,8 @@
     )
 ) @i18n.get_trans_fn
 
-;; getTranslations 関数呼び出し (Server Components)
-;; 引数: (namespace?) または ({ namespace?: string, locale?: string })
+;; getTranslations (Server Components)
+;; Args: (namespace?) or ({ namespace?: string, locale?: string })
 (variable_declarator
   name: (identifier) @i18n.get_trans_fn_name
   value:
@@ -22,9 +22,9 @@
     )
 ) @i18n.get_trans_fn
 
-;; getTranslations オブジェクト引数の namespace 抽出
+;; getTranslations with object argument: namespace extraction
 ;; await getTranslations({ namespace: "common" })
-;; next-intl の namespace は key prefix として機能する
+;; In next-intl, namespace acts as a key prefix
 (variable_declarator
   name: (identifier) @i18n.get_trans_fn_name
   value:

--- a/queries/tsx/next-intl.scm
+++ b/queries/tsx/next-intl.scm
@@ -8,3 +8,38 @@
       arguments: (arguments) @i18n.get_trans_fn_args
     )
 ) @i18n.get_trans_fn
+
+;; getTranslations 関数呼び出し (Server Components)
+;; 引数: (namespace?) または ({ namespace?: string, locale?: string })
+(variable_declarator
+  name: (identifier) @i18n.get_trans_fn_name
+  value:
+    (await_expression
+      (call_expression
+        function: (identifier) @use_translations (#eq? @use_translations "getTranslations")
+        arguments: (arguments) @i18n.get_trans_fn_args
+      )
+    )
+) @i18n.get_trans_fn
+
+;; getTranslations オブジェクト引数の namespace 抽出
+;; await getTranslations({ namespace: "common" })
+;; next-intl の namespace は key prefix として機能する
+(variable_declarator
+  name: (identifier) @i18n.get_trans_fn_name
+  value:
+    (await_expression
+      (call_expression
+        function: (identifier) @use_translations (#eq? @use_translations "getTranslations")
+        arguments:
+          (arguments
+            (object
+              (pair
+                key: (property_identifier) @_ns_key (#eq? @_ns_key "namespace")
+                value: (string (string_fragment) @i18n.trans_key_prefix)
+              )
+            )
+          )
+      )
+    )
+) @i18n.get_trans_fn

--- a/queries/tsx/react-i18next.scm
+++ b/queries/tsx/react-i18next.scm
@@ -80,7 +80,7 @@
   )
 )
 
-;; Translation コンポーネント
+;; Translation component
 (jsx_element
   open_tag: (jsx_opening_element
     name: (identifier) @translation (#eq? @translation "Translation")
@@ -100,7 +100,7 @@
   )
 ) @i18n.get_trans_fn
 
-;; Trans コンポーネント (self-closing)
+;; Trans component (self-closing)
 (jsx_self_closing_element
   name: (identifier) @trans (#eq? @trans "Trans")
   attribute: (jsx_attribute
@@ -116,7 +116,7 @@
   )?
 ) @i18n.call_trans_fn
 
-;; Trans コンポーネント (self-closing, Selector API)
+;; Trans component (self-closing, Selector API)
 (jsx_self_closing_element
   name: (identifier) @trans (#eq? @trans "Trans")
   attribute: (jsx_attribute
@@ -131,7 +131,7 @@
   )?
 ) @i18n.call_trans_fn
 
-;; Trans コンポーネント (opening element)
+;; Trans component (opening element)
 (jsx_opening_element
   name: (identifier) @trans (#eq? @trans "Trans")
   attribute: (jsx_attribute
@@ -147,7 +147,7 @@
   )?
 ) @i18n.call_trans_fn
 
-;; Trans コンポーネント (opening element, Selector API)
+;; Trans component (opening element, Selector API)
 (jsx_opening_element
   name: (identifier) @trans (#eq? @trans "Trans")
   attribute: (jsx_attribute

--- a/queries/typescript/i18next.scm
+++ b/queries/typescript/i18next.scm
@@ -1,5 +1,5 @@
-;; getFixedT 関数呼び出し
-;; 引数: (lang, ns?, keyPrefix?)
+;; getFixedT call
+;; Args: (lang, ns?, keyPrefix?)
 (variable_declarator
   name: (identifier) @i18n.get_trans_fn_name
   value:

--- a/queries/typescript/next-intl.scm
+++ b/queries/typescript/next-intl.scm
@@ -1,5 +1,5 @@
-;; useTranslations 関数呼び出し
-;; 引数: (namespace?)
+;; useTranslations hook
+;; Args: (namespace?)
 (variable_declarator
   name: (identifier) @i18n.get_trans_fn_name
   value:
@@ -9,8 +9,8 @@
     )
 ) @i18n.get_trans_fn
 
-;; getTranslations 関数呼び出し (Server Components)
-;; 引数: (namespace?) または ({ namespace?: string, locale?: string })
+;; getTranslations (Server Components)
+;; Args: (namespace?) or ({ namespace?: string, locale?: string })
 (variable_declarator
   name: (identifier) @i18n.get_trans_fn_name
   value:
@@ -22,9 +22,9 @@
     )
 ) @i18n.get_trans_fn
 
-;; getTranslations オブジェクト引数の namespace 抽出
+;; getTranslations with object argument: namespace extraction
 ;; await getTranslations({ namespace: "common" })
-;; next-intl の namespace は key prefix として機能する
+;; In next-intl, namespace acts as a key prefix
 (variable_declarator
   name: (identifier) @i18n.get_trans_fn_name
   value:

--- a/queries/typescript/next-intl.scm
+++ b/queries/typescript/next-intl.scm
@@ -8,3 +8,38 @@
       arguments: (arguments) @i18n.get_trans_fn_args
     )
 ) @i18n.get_trans_fn
+
+;; getTranslations 関数呼び出し (Server Components)
+;; 引数: (namespace?) または ({ namespace?: string, locale?: string })
+(variable_declarator
+  name: (identifier) @i18n.get_trans_fn_name
+  value:
+    (await_expression
+      (call_expression
+        function: (identifier) @use_translations (#eq? @use_translations "getTranslations")
+        arguments: (arguments) @i18n.get_trans_fn_args
+      )
+    )
+) @i18n.get_trans_fn
+
+;; getTranslations オブジェクト引数の namespace 抽出
+;; await getTranslations({ namespace: "common" })
+;; next-intl の namespace は key prefix として機能する
+(variable_declarator
+  name: (identifier) @i18n.get_trans_fn_name
+  value:
+    (await_expression
+      (call_expression
+        function: (identifier) @use_translations (#eq? @use_translations "getTranslations")
+        arguments:
+          (arguments
+            (object
+              (pair
+                key: (property_identifier) @_ns_key (#eq? @_ns_key "namespace")
+                value: (string (string_fragment) @i18n.trans_key_prefix)
+              )
+            )
+          )
+      )
+    )
+) @i18n.get_trans_fn

--- a/src/framework/next_intl.rs
+++ b/src/framework/next_intl.rs
@@ -28,14 +28,14 @@ impl I18nLibrary for NextIntl {
         func_name: &str,
         string_args: &[Option<String>],
     ) -> Option<ParsedTransFnArgs> {
-        if func_name != "useTranslations" {
-            return None;
+        match func_name {
+            // useTranslations(namespace?) / getTranslations(namespace?)
+            // In next-intl, the namespace parameter acts as a key prefix
+            "useTranslations" | "getTranslations" => Some(ParsedTransFnArgs {
+                namespace: None,
+                key_prefix: string_args.first().and_then(Clone::clone),
+            }),
+            _ => None,
         }
-        // useTranslations(namespace?)
-        // In next-intl, the namespace parameter acts as a key prefix
-        Some(ParsedTransFnArgs {
-            namespace: None,
-            key_prefix: string_args.first().and_then(Clone::clone),
-        })
     }
 }

--- a/src/syntax/analyzer/extractor.rs
+++ b/src/syntax/analyzer/extractor.rs
@@ -1292,6 +1292,79 @@ mod tests {
         assert_that!(calls, elements_are![field!(TransFnCall.key, eq("common.hello"))]);
     }
 
+    #[rstest]
+    fn test_next_intl_get_translations_string_arg(queries: Vec<Query>, js_lang: Language) {
+        let code = r#"
+            const t = await getTranslations("common");
+            const message = t("hello");
+        "#;
+
+        let calls =
+            analyze_trans_fn_calls(code, &js_lang, ProgrammingLanguage::JavaScript, &queries, ".")
+                .unwrap();
+
+        assert_that!(calls, elements_are![field!(TransFnCall.key, eq("common.hello"))]);
+    }
+
+    #[rstest]
+    fn test_next_intl_get_translations_without_arg(queries: Vec<Query>, js_lang: Language) {
+        let code = r#"
+            const t = await getTranslations();
+            const message = t("hello");
+        "#;
+
+        let calls =
+            analyze_trans_fn_calls(code, &js_lang, ProgrammingLanguage::JavaScript, &queries, ".")
+                .unwrap();
+
+        assert_that!(calls, elements_are![field!(TransFnCall.key, eq("hello"))]);
+    }
+
+    #[rstest]
+    fn test_next_intl_get_translations_object_arg(queries: Vec<Query>, js_lang: Language) {
+        let code = r#"
+            const t = await getTranslations({ locale: "en", namespace: "common" });
+            const message = t("hello");
+        "#;
+
+        let calls =
+            analyze_trans_fn_calls(code, &js_lang, ProgrammingLanguage::JavaScript, &queries, ".")
+                .unwrap();
+
+        assert_that!(calls, elements_are![field!(TransFnCall.key, eq("common.hello"))]);
+    }
+
+    #[rstest]
+    fn test_next_intl_get_translations_object_arg_namespace_only(
+        queries: Vec<Query>,
+        js_lang: Language,
+    ) {
+        let code = r#"
+            const t = await getTranslations({ namespace: "common" });
+            const message = t("hello");
+        "#;
+
+        let calls =
+            analyze_trans_fn_calls(code, &js_lang, ProgrammingLanguage::JavaScript, &queries, ".")
+                .unwrap();
+
+        assert_that!(calls, elements_are![field!(TransFnCall.key, eq("common.hello"))]);
+    }
+
+    #[rstest]
+    fn test_next_intl_get_translations_t_rich(queries: Vec<Query>, js_lang: Language) {
+        let code = r#"
+            const t = await getTranslations("common");
+            const message = t.rich("hello", { strong: (chunks) => chunks });
+        "#;
+
+        let calls =
+            analyze_trans_fn_calls(code, &js_lang, ProgrammingLanguage::JavaScript, &queries, ".")
+                .unwrap();
+
+        assert_that!(calls, elements_are![field!(TransFnCall.key, eq("common.hello"))]);
+    }
+
     // ===== react-i18next Trans/Translation component tests =====
 
     #[rstest]


### PR DESCRIPTION
## Summary

Add support for next-intl's async `getTranslations()` function used in Server Components, Server Actions, and Metadata API.

Supported patterns:
- `await getTranslations("namespace")` — string argument
- `await getTranslations({ namespace: "common" })` — object argument
- `await getTranslations({ locale: "en", namespace: "common" })` — with explicit locale

Also unifies all `.scm` query file comments to English.

## How to test

1. Open `playground/next-intl/getTranslations.tsx` in an editor with the LSP enabled
2. Verify that completion, hover, and diagnostics work for translation keys in `getTranslations`-acquired `t` functions
3. Verify all patterns: no arg, string arg, object arg with namespace, object arg with locale + namespace
4. Verify method chains (`t.rich()`, `t.markup()`, `t.raw()`) work after `getTranslations`

## Checklist

- [x] No new dependencies without justification
- [x] Documentation updated (`README.md`, `docs/`)
- [x] Tests added/updated for new behavior